### PR TITLE
fix -Wint-conversion

### DIFF
--- a/src/mantle/mantle_cmd_buf_man.c
+++ b/src/mantle/mantle_cmd_buf_man.c
@@ -43,7 +43,7 @@ GR_RESULT grCreateCommandBuffer(
         .grPipeline = NULL,
         .grDescriptorSet = NULL,
         .attachmentCount = 0,
-        .attachments = { NULL },
+        .attachments = { 0 },
         .minExtent2D = { 0, 0 },
         .minLayerCount = 0,
         .hasActiveRenderPass = false,


### PR DESCRIPTION
```
mantle_cmd_buf_man.c:46:26: warning: initialization of 'long long unsigned int' from 'void *' makes integer from pointer without a cast [-Wint-conversion]
   46 |         .attachments = { NULL },
      |                          ^~~~
../src/mantle/mantle_cmd_buf_man.c:46:26: note: (near initialization for '(anonymous).attachments[0]')
```