### PR TITLE
Descriptor sets re-implementation

### DIFF
--- a/src/amdilc/amdilc.c
+++ b/src/amdilc/amdilc.c
@@ -114,7 +114,8 @@ static void dumpKernel(
 
 IlcShader ilcCompileShader(
     const void* code,
-    unsigned size)
+    unsigned size,
+    const GR_PIPELINE_SHADER* mappings)
 {
     char name[NAME_LEN];
     getShaderName(name, NAME_LEN, code, size);
@@ -128,7 +129,7 @@ IlcShader ilcCompileShader(
         dumpKernel(kernel, name);
     }
 
-    IlcShader shader = ilcCompileKernel(kernel, name);
+    IlcShader shader = ilcCompileKernel(kernel, name, mappings);
 
     if (dump) {
         dumpBuffer((uint8_t*)shader.code, shader.codeSize, name, "spv");

--- a/src/amdilc/amdilc.h
+++ b/src/amdilc/amdilc.h
@@ -2,27 +2,34 @@
 #define AMDILC_H_
 
 #include <stdio.h>
+#include <stdbool.h>
 #include <stdint.h>
+#include <mantle/mantle.h>
 #define VK_NO_PROTOTYPES
 #include "vulkan/vulkan.h"
 
 #define ILC_BASE_RESOURCE_ID    (16) // Samplers use 0-15
 
-typedef struct _IlcBinding {
-    uint32_t index;
-    VkDescriptorType descriptorType;
-} IlcBinding;
+
+enum IlcDescriptorResourceTable {
+    TABLE_UNIFORM_TEXEL_BUFFER = 0,
+    TABLE_STORAGE_TEXEL_BUFFER = 1,
+    TABLE_STORAGE_BUFFER = 2,
+    TABLE_STORAGE_IMAGE = 3,
+    TABLE_SAMPLED_IMAGE = 4,
+    TABLE_SAMPLER = 5,
+    TABLE_MAX_ID  = 6,
+};
 
 typedef struct _IlcShader {
     unsigned codeSize;
     uint32_t* code;
-    unsigned bindingCount;
-    IlcBinding* bindings;
 } IlcShader;
 
 IlcShader ilcCompileShader(
     const void* code,
-    unsigned size);
+    unsigned size,
+    const GR_PIPELINE_SHADER* mappings);
 
 void ilcDisassembleShader(
     FILE* file,

--- a/src/amdilc/amdilc_compiler.c
+++ b/src/amdilc/amdilc_compiler.c
@@ -23,6 +23,9 @@
 #define DYNAMIC_MEMORY_RESOURCE_BINDING (0)
 #define DYNAMIC_MEMORY_UAV_BINDING (1)
 #define DYNAMIC_MEMORY_STRUCT_BUFFER_BINDING (2)
+// TODO: move this to options
+#define DESCRIPTOR_TABLE_SIZE (8192)
+
 typedef struct {
     IlcSpvId id;
     IlcSpvId typeId;
@@ -540,7 +543,7 @@ static const IlcSampler* findOrCreateSampler(
 
     if (sampler == NULL) {
         if (compiler->samplerId == 0) {
-            IlcSpvId counterId = ilcSpvPutTypeConstant(compiler->module, compiler->uintId, 10240);
+            IlcSpvId counterId = ilcSpvPutTypeConstant(compiler->module, compiler->uintId, DESCRIPTOR_TABLE_SIZE);
             compiler->samplerId = ilcSpvPutSamplerType(compiler->module);
             compiler->samplerPtrId = ilcSpvPutPointerType(compiler->module, SpvStorageClassUniformConstant, compiler->samplerId);
             IlcSpvId samplerRepoArrayType = ilcSpvPutArrayType(compiler->module, compiler->samplerId, counterId);
@@ -1228,7 +1231,7 @@ static const IlcResource* createBufferResource(
         else {
             IlcSpvWord descriptorSetIndex = 0;
             IlcSpvWord descriptorSetBinding = TABLE_STORAGE_BUFFER;
-            IlcSpvId counterId = ilcSpvPutTypeConstant(compiler->module, compiler->uintId, 10240);
+            IlcSpvId counterId = ilcSpvPutTypeConstant(compiler->module, compiler->uintId, DESCRIPTOR_TABLE_SIZE);
 
             IlcSpvId imageRepoArrayType = ilcSpvPutArrayType(compiler->module, structId, counterId);
             IlcSpvId pImageRepoArrayType = ilcSpvPutPointerType(compiler->module, SpvStorageClassStorageBuffer, imageRepoArrayType);
@@ -1337,7 +1340,7 @@ static const IlcResource* createResource(
             else {
                 descriptorSetBinding = isUav ? TABLE_STORAGE_IMAGE : TABLE_SAMPLED_IMAGE;
             }
-            IlcSpvId counterId = ilcSpvPutTypeConstant(compiler->module, compiler->uintId, 10240);
+            IlcSpvId counterId = ilcSpvPutTypeConstant(compiler->module, compiler->uintId, DESCRIPTOR_TABLE_SIZE);
             // unless sampled type is float, don't define an additional depth type
             if (!isUav && sampledTypeId == compiler->floatId) {
                 depthImageId = ilcSpvPutImageType(compiler->module, sampledTypeId, dim,

--- a/src/amdilc/amdilc_internal.h
+++ b/src/amdilc/amdilc_internal.h
@@ -85,6 +85,7 @@ void ilcDumpKernel(
 
 IlcShader ilcCompileKernel(
     const Kernel* kernel,
-    const char* name);
+    const char* name,
+    const GR_PIPELINE_SHADER* mappings);
 
 #endif // AMDILC_INTERNAL_H_

--- a/src/amdilc/amdilc_spirv.c
+++ b/src/amdilc/amdilc_spirv.c
@@ -441,6 +441,17 @@ IlcSpvId ilcSpvPutRuntimeArrayType(
     return putType(module, SpvOpTypeRuntimeArray, 1, &typeId, true, unique);
 }
 
+void ilcSpvPutRuntimeArrayTypeWithId(
+    IlcSpvModule* module,
+    IlcSpvId typeId,
+    IlcSpvId innerTypeId)
+{
+    IlcSpvBuffer* buffer = &module->buffer[ID_TYPES];
+    putInstr(buffer, SpvOpTypeRuntimeArray, 3);
+    putWord(buffer, typeId);
+    putWord(buffer, innerTypeId);
+}
+
 IlcSpvId ilcSpvPutStructType(
     IlcSpvModule* module,
     unsigned memberTypeIdCount,
@@ -457,6 +468,19 @@ IlcSpvId ilcSpvPutPointerType(
     const IlcSpvWord args[] = { storageClass, typeId };
 
     return putType(module, SpvOpTypePointer, 2, args, true, false);
+}
+
+void ilcSpvPutPointerTypeWithId(
+    IlcSpvModule* module,
+    IlcSpvId ptrId,
+    IlcSpvWord storageClass,
+    IlcSpvId typeId)
+{
+    IlcSpvBuffer* buffer = &module->buffer[ID_TYPES_WITH_CONSTANTS];
+    putInstr(buffer, SpvOpTypePointer, 4);
+    putWord(buffer, ptrId);
+    putWord(buffer, storageClass);
+    putWord(buffer, typeId);
 }
 
 IlcSpvId ilcSpvPutFunctionType(
@@ -894,6 +918,21 @@ IlcSpvId ilcSpvPutBitcast(
 
     IlcSpvId id = ilcSpvAllocId(module);
     putInstr(buffer, SpvOpBitcast, 4);
+    putWord(buffer, resultTypeId);
+    putWord(buffer, id);
+    putWord(buffer, operandId);
+    return id;
+}
+
+IlcSpvId ilcSpvPutConvertPtrToU(
+    IlcSpvModule* module,
+    IlcSpvId resultTypeId,
+    IlcSpvId operandId)
+{
+    IlcSpvBuffer* buffer = &module->buffer[ID_CODE];
+
+    IlcSpvId id = ilcSpvAllocId(module);
+    putInstr(buffer, SpvOpConvertPtrToU, 4);
     putWord(buffer, resultTypeId);
     putWord(buffer, id);
     putWord(buffer, operandId);

--- a/src/amdilc/amdilc_spirv.h
+++ b/src/amdilc/amdilc_spirv.h
@@ -91,6 +91,7 @@ IlcSpvId ilcSpvPutBoolType(
 
 IlcSpvId ilcSpvPutIntType(
     IlcSpvModule* module,
+    unsigned bitCount,
     bool isSigned);
 
 IlcSpvId ilcSpvPutFloatType(
@@ -144,7 +145,16 @@ IlcSpvId ilcSpvPutFunctionType(
     unsigned argTypeIdCount,
     const IlcSpvId* argTypeIds);
 
+void ilcSpvPutForwardPointerType(
+    IlcSpvModule* module,
+    IlcSpvId typeId);
+
 IlcSpvId ilcSpvPutConstant(
+    IlcSpvModule* module,
+    IlcSpvId resultTypeId,
+    IlcSpvWord literal);
+
+IlcSpvId ilcSpvPutTypeConstant(
     IlcSpvModule* module,
     IlcSpvId resultTypeId,
     IlcSpvWord literal);
@@ -177,26 +187,36 @@ IlcSpvId ilcSpvPutImageTexelPointer(
     IlcSpvId coordinateId,
     IlcSpvId sampleId);
 
+IlcSpvId ilcSpvPutAccessChain(
+    IlcSpvModule* module,
+    IlcSpvId typeId,
+    IlcSpvId srcId,
+    IlcSpvId argCount,
+    const IlcSpvId* args);
+
 IlcSpvId ilcSpvPutLoad(
     IlcSpvModule* module,
     IlcSpvId typeId,
-    IlcSpvId pointerId);
+    IlcSpvId pointerId,
+    IlcSpvId operandCount,
+    const IlcSpvId* operands);
 
 void ilcSpvPutStore(
     IlcSpvModule* module,
     IlcSpvId pointerId,
     IlcSpvId objectId);
 
-IlcSpvId ilcSpvPutAccessChain(
-    IlcSpvModule* module,
-    IlcSpvId resultTypeId,
-    IlcSpvId baseId,
-    unsigned indexIdCount,
-    const IlcSpvId* indexIds);
-
 void ilcSpvPutDecoration(
     IlcSpvModule* module,
     IlcSpvId target,
+    IlcSpvWord decoration,
+    unsigned argCount,
+    const IlcSpvWord* args);
+
+void ilcSpvPutMemberDecoration(
+    IlcSpvModule* module,
+    IlcSpvId target,
+    IlcSpvWord memberTarget,
     IlcSpvWord decoration,
     unsigned argCount,
     const IlcSpvWord* args);
@@ -292,6 +312,16 @@ IlcSpvId ilcSpvPutAtomicOp(
     IlcSpvId valueId);
 
 IlcSpvId ilcSpvPutBitcast(
+    IlcSpvModule* module,
+    IlcSpvId resultTypeId,
+    IlcSpvId operandId);
+
+IlcSpvId ilcSpvPutUConvert(
+    IlcSpvModule* module,
+    IlcSpvId resultTypeId,
+    IlcSpvId operandId);
+
+IlcSpvId ilcSpvPutConvertUToPtr(
     IlcSpvModule* module,
     IlcSpvId resultTypeId,
     IlcSpvId operandId);

--- a/src/amdilc/amdilc_spirv.h
+++ b/src/amdilc/amdilc_spirv.h
@@ -129,6 +129,11 @@ IlcSpvId ilcSpvPutRuntimeArrayType(
     IlcSpvId typeId,
     bool unique);
 
+void ilcSpvPutRuntimeArrayTypeWithId(
+    IlcSpvModule* module,
+    IlcSpvId typeId,
+    IlcSpvId innerTypeId);
+
 IlcSpvId ilcSpvPutStructType(
     IlcSpvModule* module,
     unsigned memberTypeIdCount,
@@ -136,6 +141,12 @@ IlcSpvId ilcSpvPutStructType(
 
 IlcSpvId ilcSpvPutPointerType(
     IlcSpvModule* module,
+    IlcSpvWord storageClass,
+    IlcSpvId typeId);
+
+void ilcSpvPutPointerTypeWithId(
+    IlcSpvModule* module,
+    IlcSpvId ptrId,
     IlcSpvWord storageClass,
     IlcSpvId typeId);
 
@@ -317,6 +328,11 @@ IlcSpvId ilcSpvPutBitcast(
     IlcSpvId operandId);
 
 IlcSpvId ilcSpvPutUConvert(
+    IlcSpvModule* module,
+    IlcSpvId resultTypeId,
+    IlcSpvId operandId);
+
+IlcSpvId ilcSpvPutConvertPtrToU(
     IlcSpvModule* module,
     IlcSpvId resultTypeId,
     IlcSpvId operandId);

--- a/src/amdilc/meson.build
+++ b/src/amdilc/meson.build
@@ -3,7 +3,7 @@ amdilc_src = [
   'amdilc_compiler.c',
   'amdilc_decoder.c',
   'amdilc_dump.c',
-  'amdilc_spirv.c',
+  'amdilc_spirv.c'
 ]
 
 amdilc_lib = static_library('amdilc', amdilc_src,

--- a/src/mantle/mantle_cmd_buf.c
+++ b/src/mantle/mantle_cmd_buf.c
@@ -126,23 +126,24 @@ static VkDescriptorSet allocateDynamicBindingSet(GrCmdBuffer* grCmdBuffer, VkPip
 pool_allocation:
     LOGT("Allocating a new descriptor pool for dynamic binding for buffer %p\n", grCmdBuffer);
     // TODO: make "vector" more efficient
+    grCmdBuffer->descriptorPoolCount++;
     grCmdBuffer->descriptorPools = (VkDescriptorPool*)realloc(grCmdBuffer->descriptorPools, sizeof(VkDescriptorPool) * grCmdBuffer->descriptorPoolCount);
-    const unsigned dynamicDescriptorCount = 128;
+
     const VkDescriptorPoolSize poolSizes[2] = {
         {
             .type = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,
-            .descriptorCount = dynamicDescriptorCount,
+            .descriptorCount = SETS_PER_POOL,
         },
         {
             .type = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER,
-            .descriptorCount = dynamicDescriptorCount,
+            .descriptorCount = SETS_PER_POOL,
         }
     };
     const VkDescriptorPoolCreateInfo poolCreateInfo = {
         .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
         .pNext = NULL,
         .flags = 0,
-        .maxSets = dynamicDescriptorCount,
+        .maxSets = SETS_PER_POOL,
         .poolSizeCount = 2,
         .pPoolSizes = poolSizes,
     };
@@ -152,7 +153,7 @@ pool_allocation:
         LOGE("vkCreateDescriptorPool for dynamic binding failed\n");
         assert(false);
     }
-    grCmdBuffer->descriptorPools[grCmdBuffer->descriptorPoolCount++] = tempPool;
+    grCmdBuffer->descriptorPools[grCmdBuffer->descriptorPoolCount - 1] = tempPool;
     allocInfo.descriptorPool = tempPool;
     if (VKD.vkAllocateDescriptorSets(grDevice->device, &allocInfo, &outSet) != VK_SUCCESS) {
         LOGE("vkAllocateDescriptorSets failed for created descriptor pool\n");

--- a/src/mantle/mantle_cmd_buf_man.c
+++ b/src/mantle/mantle_cmd_buf_man.c
@@ -79,13 +79,19 @@ GR_RESULT grCreateCommandBuffer(
     }
 
     GrCmdBuffer* grCmdBuffer = malloc(sizeof(GrCmdBuffer));
+    if (grCmdBuffer == NULL) {
+        return GR_ERROR_OUT_OF_MEMORY;
+    }
     *grCmdBuffer = (GrCmdBuffer) {
         .grObj = { GR_OBJ_TYPE_COMMAND_BUFFER, grDevice },
         .commandPool = vkCommandPool,
         .commandBuffer = vkCommandBuffer,
         .dirtyFlags = 0,
         .isBuilding = false,
-        .bindPoint = { { 0 }, { 0 } },
+        .bindPoint = {
+            { NULL, {NULL, NULL}, {0, 0}, {}},
+            { NULL, {NULL, NULL}, {0, 0}, {}},
+        },
         .framebuffer = VK_NULL_HANDLE,
         .attachmentCount = 0,
         .attachments = { VK_NULL_HANDLE },

--- a/src/mantle/mantle_descriptor_set.c
+++ b/src/mantle/mantle_descriptor_set.c
@@ -1,17 +1,5 @@
 #include "mantle_internal.h"
-
-static void clearDescriptorSetSlot(
-    GrDevice* grDevice,
-    DescriptorSetSlot* slot)
-{
-    if (slot->type == SLOT_TYPE_MEMORY_VIEW) {
-        // FIXME track references
-        //VKD.vkDestroyBufferView(grDevice->device, slot->memoryView.vkBufferView, NULL);
-    }
-
-    slot->type = SLOT_TYPE_NONE;
-}
-
+#include "amdilc.h"
 // Descriptor Set Functions
 
 GR_RESULT grCreateDescriptorSet(
@@ -29,32 +17,350 @@ GR_RESULT grCreateDescriptorSet(
     } else if (pCreateInfo == NULL || pDescriptorSet == NULL) {
         return GR_ERROR_INVALID_POINTER;
     }
-
-    GrDescriptorSet* grDescriptorSet = malloc(sizeof(GrDescriptorSet));
-    *grDescriptorSet = (GrDescriptorSet) {
-        .grObj = { GR_OBJ_TYPE_DESCRIPTOR_SET, grDevice },
-        .slotCount = pCreateInfo->slots,
-        .slots = calloc(pCreateInfo->slots, sizeof(DescriptorSetSlot)),
+    GR_RESULT res = GR_SUCCESS;
+    VkBufferCreateInfo ci = {
+        .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        .usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+        .size = pCreateInfo->slots * sizeof(uint64_t),
+        .queueFamilyIndexCount = 0,
+        .flags = 0,
+        .pQueueFamilyIndices = NULL,
     };
 
+    VkBuffer buffer = VK_NULL_HANDLE;
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+    //TODO: maybe handle memory binding or something
+    if (VKD.vkCreateBuffer(grDevice->device, &ci, NULL,
+                                   &buffer) != VK_SUCCESS) {
+        LOGE("vkCreatebuffer failed\n");
+        res = GR_ERROR_OUT_OF_MEMORY;
+        goto bail;
+    }
+    VkMemoryRequirements reqs;
+    VKD.vkGetBufferMemoryRequirements(grDevice->device, buffer, &reqs);
+    VkMemoryAllocateFlagsInfo allocateFlags = {
+        .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO,
+        .pNext = NULL,
+        .flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT,
+        .deviceMask = 0,
+    };
+    VkMemoryAllocateInfo allocInfo = {
+        .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+        .pNext = &allocateFlags,
+        .allocationSize = reqs.size,
+        .memoryTypeIndex = grDevice->vDescriptorSetMemoryTypeIndex,
+    };
+    if (VKD.vkAllocateMemory(grDevice->device, &allocInfo, NULL,//TODO: add custom allocator (enough to radv's VkDescriptorPool) to reduce overhead
+                                   &memory) != VK_SUCCESS) {
+        LOGE("descriptor allocation failed\n");
+        res = GR_ERROR_OUT_OF_GPU_MEMORY;
+        goto bail;
+    }
+    if (VKD.vkBindBufferMemory(grDevice->device, buffer, memory, 0) != VK_SUCCESS) {
+        LOGE("descriptor buffer memory bind failed\n");
+        res = GR_ERROR_OUT_OF_GPU_MEMORY;
+        goto bail;
+    }
+    DescriptorSetSlot* slots = malloc(sizeof(DescriptorSetSlot) * pCreateInfo->slots);
+    DescriptorSetSlot* tempSlots = malloc(sizeof(DescriptorSetSlot) * pCreateInfo->slots);
+    memset(slots, 0, sizeof(DescriptorSetSlot) * pCreateInfo->slots);
+    memset(tempSlots, 0, sizeof(DescriptorSetSlot) * pCreateInfo->slots);
+
+    VkBufferDeviceAddressInfo bufferAddrInfo = {
+        .sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO,
+        .buffer = buffer,
+    };
+    GrDescriptorSet* grDescriptorSet = malloc(sizeof(GrDescriptorSet));
+    if (grDescriptorSet == NULL) {
+        LOGE("descriptor set structure allocation failed\n");
+        res = GR_ERROR_OUT_OF_MEMORY;
+        goto bail;
+    }
+    *grDescriptorSet = (GrDescriptorSet) {
+        .grObj = { GR_OBJ_TYPE_DESCRIPTOR_SET, grDevice},
+        .slots = slots,
+        .tempSlots = tempSlots,
+        .slotCount = pCreateInfo->slots,
+        .virtualDescriptorSet = buffer,
+        .boundMemory = memory,
+        .bufferDevicePtr = VKD.vkGetBufferDeviceAddress(grDevice->device, &bufferAddrInfo)
+    };
+
+    if (VKD.vkMapMemory(grDescriptorSet->grObj.grDevice->device, grDescriptorSet->boundMemory, 0, sizeof(uint64_t) * grDescriptorSet->slotCount, 0, (void**)&grDescriptorSet->boundMemoryHostPtr) != VK_SUCCESS) {
+        res = GR_ERROR_OUT_OF_MEMORY;
+        goto bail;
+    }
     *pDescriptorSet = (GR_DESCRIPTOR_SET)grDescriptorSet;
     return GR_SUCCESS;
+bail:
+    if (grDescriptorSet != NULL) {
+        free(grDescriptorSet);
+    }
+    if (buffer != VK_NULL_HANDLE) {
+        VKD.vkDestroyBuffer(grDevice->device, buffer, NULL);
+    }
+    if (memory != VK_NULL_HANDLE) {
+        VKD.vkFreeMemory(grDevice->device, memory, NULL);
+    }
+    return res;
+}
+
+static unsigned allocateRealDescriptorSet(GrGlobalDescriptorSet* descriptorSet, DescriptorSetSlot* slot)
+{
+    //TODO: make this atomic or locked at least
+    unsigned index = 0xFFFFFFFF;
+    if (slot->type == SLOT_TYPE_IMAGE_VIEW) {
+        bool* currentPtr = descriptorSet->imagePtr;
+        do {
+            if (!*descriptorSet->imagePtr) {
+                index = descriptorSet->imagePtr - descriptorSet->images;
+                *descriptorSet->imagePtr = true;
+            }
+            if (descriptorSet->imagePtr >= descriptorSet->images + descriptorSet->descriptorCount) {
+                descriptorSet->imagePtr = descriptorSet->images;
+            }
+            else {
+                descriptorSet->imagePtr++;
+            }
+        } while (currentPtr != descriptorSet->imagePtr && index == 0xFFFFFFFF);
+    }
+    else if (slot->type == SLOT_TYPE_MEMORY_VIEW) {
+        bool* currentPtr = descriptorSet->bufferViewPtr;
+        do {
+            if (!*descriptorSet->bufferViewPtr) {
+                index = descriptorSet->bufferViewPtr - descriptorSet->bufferViews;
+                *descriptorSet->bufferViewPtr = true;
+            }
+            if (descriptorSet->bufferViewPtr >= descriptorSet->bufferViews + descriptorSet->descriptorCount) {
+                descriptorSet->bufferViewPtr = descriptorSet->bufferViews;
+            }
+            else {
+                descriptorSet->bufferViewPtr++;
+            }
+        } while (currentPtr != descriptorSet->bufferViewPtr && index == 0xFFFFFFFF);
+    }
+    else if (slot->type == SLOT_TYPE_SAMPLER) {
+        bool* currentPtr = descriptorSet->samplerPtr;
+        do {
+            if (!*descriptorSet->samplerPtr) {
+                index = descriptorSet->samplerPtr - descriptorSet->samplers;
+                *descriptorSet->samplerPtr = true;
+            }
+            if (descriptorSet->samplerPtr >= descriptorSet->samplers + descriptorSet->descriptorCount) {
+                descriptorSet->samplerPtr = descriptorSet->samplers;
+            }
+            else {
+                descriptorSet->samplerPtr++;
+            }
+        } while (currentPtr != descriptorSet->samplerPtr && index == 0xFFFFFFFF);
+    }
+    return index;//idk
 }
 
 GR_VOID grBeginDescriptorSetUpdate(
     GR_DESCRIPTOR_SET descriptorSet)
 {
     LOGT("%p\n", descriptorSet);
-
-    // TODO dirty tracking
+    GrDescriptorSet* grDescriptorSet = (GrDescriptorSet*)descriptorSet;
+    // prepare the diff
+    memcpy(grDescriptorSet->tempSlots, grDescriptorSet->slots, sizeof(DescriptorSetSlot) * grDescriptorSet->slotCount);
 }
 
 GR_VOID grEndDescriptorSetUpdate(
     GR_DESCRIPTOR_SET descriptorSet)
 {
     LOGT("%p\n", descriptorSet);
+    GrDescriptorSet* grDescriptorSet = (GrDescriptorSet*)descriptorSet;
+    GrDevice* grDevice = GET_OBJ_DEVICE(grDescriptorSet);
+    uint64_t* descriptorSetHostBuffer = (uint64_t*)grDescriptorSet->boundMemoryHostPtr;
 
-    // TODO update descriptors of bound pipelines
+    VkWriteDescriptorSet* writeDescriptorSet = (VkWriteDescriptorSet*)malloc(grDescriptorSet->slotCount * sizeof(VkWriteDescriptorSet) * 3);
+    VkDescriptorImageInfo* imageInfos = (VkDescriptorImageInfo*)malloc(grDescriptorSet->slotCount * sizeof(VkDescriptorImageInfo));
+    VkDescriptorBufferInfo* bufferInfos = (VkDescriptorBufferInfo*)malloc(grDescriptorSet->slotCount * sizeof(VkDescriptorBufferInfo));
+    unsigned writeCount = 0;
+    unsigned imageInfoCount = 0;
+    unsigned bufferInfoCount = 0;
+    for (int j = 0; j < grDescriptorSet->slotCount; j++) {
+        DescriptorSetSlot* slot = &((DescriptorSetSlot*)grDescriptorSet->slots)[j];
+        DescriptorSetSlot* tempSlot = &((DescriptorSetSlot*)grDescriptorSet->tempSlots)[j];
+        bool freeExistingSlot = false;
+        bool allocSlot = false;
+        if (tempSlot->type != slot->type) {
+            // allocate descriptor set anyway
+            freeExistingSlot = (slot->type != SLOT_TYPE_NESTED && slot->type != SLOT_TYPE_NONE);
+            allocSlot = (tempSlot->type != SLOT_TYPE_NESTED && tempSlot->type != SLOT_TYPE_NONE);
+        }
+
+        if (freeExistingSlot) {
+            switch (slot->type) {
+            case SLOT_TYPE_IMAGE_VIEW:
+                grDescriptorSet->grObj.grDevice->globalDescriptorSet.images[slot->realDescriptorIndex] = false;
+                slot->imageView = VK_NULL_HANDLE;
+                break;
+            case SLOT_TYPE_MEMORY_VIEW:
+                if (slot->bufferView != VK_NULL_HANDLE) {
+                    VKD.vkDestroyBufferView(grDescriptorSet->grObj.grDevice->device, slot->bufferView, NULL);
+                    slot->bufferView = VK_NULL_HANDLE;
+                    slot->bufferViewCreateInfo.buffer = VK_NULL_HANDLE;
+                }
+                grDescriptorSet->grObj.grDevice->globalDescriptorSet.bufferViews[slot->realDescriptorIndex] = false;
+                break;
+            case SLOT_TYPE_SAMPLER:
+                grDescriptorSet->grObj.grDevice->globalDescriptorSet.samplers[slot->realDescriptorIndex] = false;
+                slot->sampler = VK_NULL_HANDLE;
+                break;
+            default:
+                break;
+            }
+        }
+
+        slot->type = tempSlot->type;
+        if (allocSlot) {
+            slot->realDescriptorIndex = allocateRealDescriptorSet(&grDescriptorSet->grObj.grDevice->globalDescriptorSet, slot);
+            descriptorSetHostBuffer[j] = (uint64_t)slot->realDescriptorIndex;
+        }
+        if (slot->type == SLOT_TYPE_NESTED) {
+            slot->nestedDescriptorSet = tempSlot->nestedDescriptorSet;
+            descriptorSetHostBuffer[j] = slot->nestedDescriptorSet;
+        }
+        else if (slot->type == SLOT_TYPE_IMAGE_VIEW) {
+            slot->nestedDescriptorSet = 0;
+            //update descriptor set
+            if (slot->imageView != tempSlot->imageView || slot->imageLayout != tempSlot->imageLayout) {
+                imageInfos[imageInfoCount] = (VkDescriptorImageInfo) {
+                    .sampler = VK_NULL_HANDLE,
+                    .imageView = tempSlot->imageView,
+                    .imageLayout = tempSlot->imageLayout,
+                };
+                if (tempSlot->imageUsage & VK_IMAGE_USAGE_STORAGE_BIT) {
+                    writeDescriptorSet[writeCount++] = (VkWriteDescriptorSet) {
+                        .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+                        .pNext = NULL,
+                        .dstSet = grDescriptorSet->grObj.grDevice->globalDescriptorSet.descriptorTable,
+                        .dstBinding = TABLE_STORAGE_IMAGE,
+                        .dstArrayElement = slot->realDescriptorIndex,
+                        .descriptorCount = 1,
+                        .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+                        .pImageInfo = &imageInfos[imageInfoCount],
+                        .pBufferInfo = NULL,
+                        .pTexelBufferView = NULL,
+                    };
+                }
+                if (tempSlot->imageUsage & VK_IMAGE_USAGE_SAMPLED_BIT) {
+                    writeDescriptorSet[writeCount++] = (VkWriteDescriptorSet) {
+                        .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+                        .pNext = NULL,
+                        .dstSet = grDescriptorSet->grObj.grDevice->globalDescriptorSet.descriptorTable,
+                        .dstBinding = TABLE_SAMPLED_IMAGE,
+                        .dstArrayElement = slot->realDescriptorIndex,
+                        .descriptorCount = 1,
+                        .descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
+                        .pImageInfo = &imageInfos[imageInfoCount],
+                        .pBufferInfo = NULL,
+                        .pTexelBufferView = NULL,
+                    };
+                }
+                imageInfoCount++;
+            }
+
+            slot->imageView = tempSlot->imageView;
+            slot->imageLayout = tempSlot->imageLayout;
+            slot->imageUsage = tempSlot->imageUsage;
+        }
+        else if (slot->type == SLOT_TYPE_MEMORY_VIEW) {
+            slot->nestedDescriptorSet = 0;
+            if (slot->bufferView == VK_NULL_HANDLE || memcmp(&slot->bufferViewCreateInfo, &tempSlot->bufferViewCreateInfo, sizeof(VkBufferViewCreateInfo)) != 0) {
+                if (slot->bufferView != VK_NULL_HANDLE) {
+                    VKD.vkDestroyBufferView(grDescriptorSet->grObj.grDevice->device, slot->bufferView, NULL);
+                }
+                memcpy(&slot->bufferViewCreateInfo, &tempSlot->bufferViewCreateInfo, sizeof(VkBufferViewCreateInfo));
+                if (tempSlot->bufferViewCreateInfo.format != VK_FORMAT_UNDEFINED) {
+                    if (VKD.vkCreateBufferView(grDescriptorSet->grObj.grDevice->device, &tempSlot->bufferViewCreateInfo, NULL,
+                                               &tempSlot->bufferView) != VK_SUCCESS) {
+                        LOGE("vkCreateBufferView failed\n");
+                        assert(false);
+                    }
+                    if (tempSlot->bufferUsage & VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT) {
+                        writeDescriptorSet[writeCount++] = (VkWriteDescriptorSet) {
+                            .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+                            .pNext = NULL,
+                            .dstSet = grDescriptorSet->grObj.grDevice->globalDescriptorSet.descriptorTable,
+                            .dstBinding = TABLE_STORAGE_TEXEL_BUFFER,
+                            .dstArrayElement = slot->realDescriptorIndex,
+                            .descriptorCount = 1,
+                            .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER,
+                            .pImageInfo = NULL,
+                            .pBufferInfo = NULL,
+                            .pTexelBufferView = &tempSlot->bufferView,
+                        };
+                    }
+                    writeDescriptorSet[writeCount++] = (VkWriteDescriptorSet) {
+                        .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+                        .pNext = NULL,
+                        .dstSet = grDescriptorSet->grObj.grDevice->globalDescriptorSet.descriptorTable,
+                        .dstBinding = TABLE_UNIFORM_TEXEL_BUFFER,
+                        .dstArrayElement = slot->realDescriptorIndex,
+                        .descriptorCount = 1,
+                        .descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,
+                        .pImageInfo = NULL,
+                        .pBufferInfo = NULL,
+                        .pTexelBufferView = &tempSlot->bufferView,
+                    };
+                }
+                if (tempSlot->bufferUsage & VK_BUFFER_USAGE_STORAGE_BUFFER_BIT) {
+                    bufferInfos[bufferInfoCount] = (VkDescriptorBufferInfo) {
+                        .buffer = tempSlot->bufferViewCreateInfo.buffer,
+                        .offset = tempSlot->bufferViewCreateInfo.offset,
+                        .range  = tempSlot->bufferViewCreateInfo.range,
+                    };
+                    writeDescriptorSet[writeCount++] = (VkWriteDescriptorSet) {
+                        .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+                        .pNext = NULL,
+                        .dstSet = grDescriptorSet->grObj.grDevice->globalDescriptorSet.descriptorTable,
+                        .dstBinding = TABLE_STORAGE_BUFFER,
+                        .dstArrayElement = slot->realDescriptorIndex,
+                        .descriptorCount = 1,
+                        .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+                        .pImageInfo = NULL,
+                        .pBufferInfo = &bufferInfos[bufferInfoCount],
+                        .pTexelBufferView = NULL,
+                    };
+                    bufferInfoCount++;
+                }
+                slot->bufferView = tempSlot->bufferView;
+            }
+        }
+        else if (slot->type == SLOT_TYPE_SAMPLER) {
+            slot->nestedDescriptorSet = 0;
+            imageInfos[imageInfoCount] = (VkDescriptorImageInfo) {
+                .sampler = tempSlot->sampler,
+                .imageView = VK_NULL_HANDLE,
+                .imageLayout = VK_NULL_HANDLE,
+            };
+            writeDescriptorSet[writeCount++] = (VkWriteDescriptorSet) {
+
+                .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+                .pNext = NULL,
+                .dstSet = grDescriptorSet->grObj.grDevice->globalDescriptorSet.descriptorTable,
+                .dstBinding = TABLE_SAMPLER,
+                .dstArrayElement = slot->realDescriptorIndex,
+                .descriptorCount = 1,
+                .descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER,
+                .pImageInfo = &imageInfos[imageInfoCount],
+                .pBufferInfo = NULL,
+                .pTexelBufferView = NULL,
+            };
+            imageInfoCount++;
+            slot->sampler = tempSlot->sampler;
+        }
+    }
+
+    VKD.vkUpdateDescriptorSets(grDescriptorSet->grObj.grDevice->device, writeCount, writeDescriptorSet,
+                               0, NULL);
+    free(writeDescriptorSet);
+    free(imageInfos);
+    free(bufferInfos);
 }
 
 GR_VOID grAttachSamplerDescriptors(
@@ -65,18 +371,17 @@ GR_VOID grAttachSamplerDescriptors(
 {
     LOGT("%p %u %u %p\n", descriptorSet, startSlot, slotCount, pSamplers);
     GrDescriptorSet* grDescriptorSet = (GrDescriptorSet*)descriptorSet;
-    GrDevice* grDevice = GET_OBJ_DEVICE(grDescriptorSet);
 
-    for (unsigned i = 0; i < slotCount; i++) {
-        DescriptorSetSlot* slot = &grDescriptorSet->slots[startSlot + i];
-        const GrSampler* grSampler = (GrSampler*)pSamplers[i];
-
-        clearDescriptorSetSlot(grDevice, slot);
-
-        *slot = (DescriptorSetSlot) {
-            .type = SLOT_TYPE_SAMPLER,
-            .sampler.vkSampler = grSampler->sampler,
-        };
+    for (int i = 0; i < slotCount; i++) {
+        DescriptorSetSlot* tempSlot = &((DescriptorSetSlot*)grDescriptorSet->tempSlots)[startSlot + i];
+        const GrSampler* sampler = (GrSampler*)pSamplers[i];
+        if (sampler != NULL) {
+            tempSlot->sampler = sampler->sampler;
+        }
+        else {
+            tempSlot->sampler = VK_NULL_HANDLE;
+        }
+        tempSlot->type = SLOT_TYPE_SAMPLER;
     }
 }
 
@@ -88,22 +393,29 @@ GR_VOID grAttachImageViewDescriptors(
 {
     LOGT("%p %u %u %p\n", descriptorSet, startSlot, slotCount, pImageViews);
     GrDescriptorSet* grDescriptorSet = (GrDescriptorSet*)descriptorSet;
-    GrDevice* grDevice = GET_OBJ_DEVICE(grDescriptorSet);
 
-    for (unsigned i = 0; i < slotCount; i++) {
-        DescriptorSetSlot* slot = &grDescriptorSet->slots[startSlot + i];
-        const GR_IMAGE_VIEW_ATTACH_INFO* info = &pImageViews[i];
-        const GrImageView* grImageView = (GrImageView*)info->view;
+    for (int i = 0; i < slotCount; i++) {
+        DescriptorSetSlot* tempSlot = &((DescriptorSetSlot*)grDescriptorSet->tempSlots)[startSlot + i];
+        tempSlot->imageLayout = getVkImageLayout(pImageViews[i].state);
+        const GrImageView* imageView = (GrImageView*)pImageViews[i].view;
+        if (imageView == NULL) {//don't want to cause segfault
+            tempSlot->imageView = VK_NULL_HANDLE;
+        }
+        else {
+            tempSlot->imageView = imageView->imageView;
+            tempSlot->imageUsage = imageView->usage;
+        }
+        tempSlot->type = SLOT_TYPE_IMAGE_VIEW;
+    }
+}
 
-        clearDescriptorSetSlot(grDevice, slot);
-
-        *slot = (DescriptorSetSlot) {
-            .type = SLOT_TYPE_IMAGE_VIEW,
-            .imageView = {
-                .vkImageView = grImageView->imageView,
-                .vkImageLayout = getVkImageLayout(info->state),
-            },
-        };
+VkBufferUsageFlags getVkBufferUsages(GR_MEMORY_STATE state) {
+    switch (state) {
+    case GR_MEMORY_STATE_GRAPHICS_SHADER_READ_ONLY:
+    case GR_MEMORY_STATE_COMPUTE_SHADER_READ_ONLY:
+        return VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
+    default:
+        return VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
     }
 }
 
@@ -115,24 +427,22 @@ GR_VOID grAttachMemoryViewDescriptors(
 {
     LOGT("%p %u %u %p\n", descriptorSet, startSlot, slotCount, pMemViews);
     GrDescriptorSet* grDescriptorSet = (GrDescriptorSet*)descriptorSet;
-    GrDevice* grDevice = GET_OBJ_DEVICE(grDescriptorSet);
 
-    for (unsigned i = 0; i < slotCount; i++) {
-        DescriptorSetSlot* slot = &grDescriptorSet->slots[startSlot + i];
-        const GR_MEMORY_VIEW_ATTACH_INFO* info = &pMemViews[i];
-        GrGpuMemory* grGpuMemory = (GrGpuMemory*)info->mem;
-
+    for (int i = 0; i < slotCount; i++) {
+        DescriptorSetSlot* tempSlot = &((DescriptorSetSlot*)grDescriptorSet->tempSlots)[startSlot + i];
+        const GR_MEMORY_VIEW_ATTACH_INFO* attachInfo = pMemViews + i;
+        GrGpuMemory* grGpuMemory = (GrGpuMemory*)attachInfo->mem;
+        tempSlot->type = SLOT_TYPE_MEMORY_VIEW;
         grGpuMemoryBindBuffer(grGpuMemory);
-        clearDescriptorSetSlot(grDevice, slot);
-
-        *slot = (DescriptorSetSlot) {
-            .type = SLOT_TYPE_MEMORY_VIEW,
-            .memoryView = {
-                .vkBuffer = grGpuMemory->buffer,
-                .vkFormat = getVkFormat(info->format),
-                .offset = info->offset,
-                .range = info->range,
-            },
+        tempSlot->bufferUsage = getVkBufferUsages(attachInfo->state);
+        tempSlot->bufferViewCreateInfo = (VkBufferViewCreateInfo){
+            .sType = VK_STRUCTURE_TYPE_BUFFER_VIEW_CREATE_INFO,
+            .pNext = NULL,
+            .flags = 0,
+            .buffer = grGpuMemory->buffer,
+            .format = getVkFormat(attachInfo->format),
+            .offset = attachInfo->offset,
+            .range = attachInfo->range,
         };
     }
 }
@@ -145,21 +455,12 @@ GR_VOID grAttachNestedDescriptors(
 {
     LOGT("%p %u %u %p\n", descriptorSet, startSlot, slotCount, pNestedDescriptorSets);
     GrDescriptorSet* grDescriptorSet = (GrDescriptorSet*)descriptorSet;
-    GrDevice* grDevice = GET_OBJ_DEVICE(grDescriptorSet);
 
-    for (unsigned i = 0; i < slotCount; i++) {
-        DescriptorSetSlot* slot = &grDescriptorSet->slots[startSlot + i];
-        const GR_DESCRIPTOR_SET_ATTACH_INFO* info = &pNestedDescriptorSets[i];
-
-        clearDescriptorSetSlot(grDevice, slot);
-
-        *slot = (DescriptorSetSlot) {
-            .type = SLOT_TYPE_NESTED,
-            .nested = {
-                .nextSet = (GrDescriptorSet*)info->descriptorSet,
-                .slotOffset = info->slotOffset,
-            },
-        };
+    for (int i = 0; i < slotCount; i++) {
+        DescriptorSetSlot* tempSlot = &((DescriptorSetSlot*)grDescriptorSet->tempSlots)[startSlot + i];
+        const GrDescriptorSet* nestedSet = (GrDescriptorSet*) pNestedDescriptorSets[i].descriptorSet;
+        tempSlot->type = SLOT_TYPE_NESTED;
+        tempSlot->nestedDescriptorSet = nestedSet->bufferDevicePtr + sizeof(uint64_t) * pNestedDescriptorSets[i].slotOffset;
     }
 }
 
@@ -170,11 +471,12 @@ GR_VOID grClearDescriptorSetSlots(
 {
     LOGT("%p %u %u\n", descriptorSet, startSlot, slotCount);
     GrDescriptorSet* grDescriptorSet = (GrDescriptorSet*)descriptorSet;
-    GrDevice* grDevice = GET_OBJ_DEVICE(grDescriptorSet);
 
-    for (unsigned i = 0; i < slotCount; i++) {
-        DescriptorSetSlot* slot = &grDescriptorSet->slots[startSlot + i];
+    for (int i = 0; i < slotCount; i++) {
+        DescriptorSetSlot* tempSlot = &((DescriptorSetSlot*)grDescriptorSet->tempSlots)[startSlot + i];
 
-        clearDescriptorSetSlot(grDevice, slot);
+        tempSlot->type = SLOT_TYPE_NONE;
+        tempSlot->bufferView = VK_NULL_HANDLE;
+        tempSlot->nestedDescriptorSet = 0;
     }
 }

--- a/src/mantle/mantle_image_view.c
+++ b/src/mantle/mantle_image_view.c
@@ -94,6 +94,7 @@ GR_RESULT grCreateImageView(
     *grImageView = (GrImageView) {
         .grObj = { GR_OBJ_TYPE_IMAGE_VIEW, grDevice },
         .imageView = vkImageView,
+        .usage = grImage->usage,
     };
 
     *pView = (GR_IMAGE_VIEW)grImageView;

--- a/src/mantle/mantle_init_device.c
+++ b/src/mantle/mantle_init_device.c
@@ -442,7 +442,7 @@ GR_RESULT grCreateDevice(
     VkPhysicalDeviceMemoryProperties memoryProperties;
     vki.vkGetPhysicalDeviceMemoryProperties(grPhysicalGpu->physicalDevice, &memoryProperties);
 
-    unsigned descriptorCount = 10240;
+    unsigned descriptorCount = 8192;
     const VkDescriptorSetLayoutBinding globalLayoutBindings[] = {
         {
             .binding = 0,
@@ -679,11 +679,11 @@ GR_RESULT grCreateDevice(
             .descriptorPool = globalPool,
             .descriptorTable = globalDescSet,
             .samplers = descriptorHandleBuffer,
-            .samplerPtr = descriptorHandleBuffer,
+            .samplerIndex = 0,
             .bufferViews = descriptorHandleBuffer + descriptorCount,
-            .bufferViewPtr = descriptorHandleBuffer + descriptorCount,//TODO: support mutable descriptors
+            .bufferViewIndex = 0,//TODO: support mutable descriptors
             .images = descriptorHandleBuffer + 2 * descriptorCount,
-            .imagePtr = descriptorHandleBuffer + 2 * descriptorCount,
+            .imageIndex = 0,
             .descriptorCount = descriptorCount,
         },
         .pipelineLayouts = globalPipelineLayouts,

--- a/src/mantle/mantle_init_device.c
+++ b/src/mantle/mantle_init_device.c
@@ -172,6 +172,73 @@ GR_RESULT grGetGpuInfo(
     return GR_SUCCESS;
 }
 
+static unsigned getVirtualDescriptorSetBufferMemoryType(const VkPhysicalDeviceMemoryProperties *memoryProps) {
+    unsigned suitableMemoryType = memoryProps->memoryTypeCount;
+    unsigned hostMemoryType = memoryProps->memoryTypeCount;
+    for (unsigned i = 0; i < memoryProps->memoryTypeCount; ++i) {
+        if ((VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) & memoryProps->memoryTypes[i].propertyFlags) {
+            hostMemoryType = i;
+            if (VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT & memoryProps->memoryTypes[i].propertyFlags) {
+                suitableMemoryType = i;
+            }
+        }
+    }
+    if (suitableMemoryType < memoryProps->memoryTypeCount) {
+        LOGT("found suitable memory type for descriptor sets: %d\n", suitableMemoryType);
+        return suitableMemoryType;
+    }
+    LOGT("fallback to host memory type for descriptor sets: %d\n", hostMemoryType);
+    return hostMemoryType;
+}
+
+VkResult getVkPipelineLayout(VkDevice vkDevice,
+                             const VULKAN_DEVICE* vkd,
+                             VkDescriptorSetLayout globalDescriptorSetLayout,
+                             VkDescriptorSetLayout graphicsDynamicMemoryLayout,
+                             VkDescriptorSetLayout computeDynamicMemoryLayout,
+                             GrGlobalPipelineLayouts* outLayouts
+    )
+{
+    const VkPushConstantRange pushRange = {
+        .stageFlags = VK_SHADER_STAGE_ALL_GRAPHICS,
+        .offset = 0,
+        .size = sizeof(uint64_t) * GR_MAX_DESCRIPTOR_SETS
+    };
+
+    const VkPushConstantRange computePushRange = {
+        .stageFlags = VK_SHADER_STAGE_COMPUTE_BIT,
+        .offset = 0,
+        .size = sizeof(uint64_t) * GR_MAX_DESCRIPTOR_SETS
+    };
+
+    const VkDescriptorSetLayout graphicsLayouts[2] = {globalDescriptorSetLayout, graphicsDynamicMemoryLayout};
+    VkPipelineLayoutCreateInfo createInfo = {
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
+        .pNext = NULL,
+        .flags = 0,
+        .setLayoutCount = 2,
+        .pSetLayouts = graphicsLayouts,
+        .pushConstantRangeCount = 1,
+        .pPushConstantRanges = &pushRange,
+    };
+    VkResult res = vkd->vkCreatePipelineLayout(vkDevice, &createInfo, NULL, &outLayouts->graphicsPipelineLayout);
+    if (res != VK_SUCCESS) {
+        LOGE("vkCreatePipelineLayout failed for graphics pipeline layout\n");
+        return res;
+    }
+
+    const VkDescriptorSetLayout computeLayouts[2] = {globalDescriptorSetLayout, computeDynamicMemoryLayout};
+    // now create compute ones
+    createInfo.pPushConstantRanges = &computePushRange;
+    createInfo.pSetLayouts = computeLayouts;
+    res = vkd->vkCreatePipelineLayout(vkDevice, &createInfo, NULL, &outLayouts->computePipelineLayout);
+    if (res != VK_SUCCESS) {
+        LOGE("vkCreatePipelineLayout failed for compute pipeline layout\n");
+        return res;
+    }
+    return VK_SUCCESS;
+}
+
 GR_RESULT grCreateDevice(
     GR_PHYSICAL_GPU gpu,
     const GR_DEVICE_CREATE_INFO* pCreateInfo,
@@ -270,14 +337,23 @@ GR_RESULT grCreateDevice(
         goto bail;
     }
 
-    const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures separateDsLayouts = {
-        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES,
+    const VkPhysicalDeviceVulkan12Features vk12DeviceFeatures = {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES,
         .pNext = NULL,
+        .descriptorBindingPartiallyBound = VK_TRUE,
+        .bufferDeviceAddress = VK_TRUE,
+        .descriptorIndexing = VK_TRUE,
         .separateDepthStencilLayouts = VK_TRUE,
+        .descriptorBindingSampledImageUpdateAfterBind = VK_TRUE,
+        .descriptorBindingStorageImageUpdateAfterBind = VK_TRUE,
+        .descriptorBindingStorageBufferUpdateAfterBind = VK_TRUE,
+        .descriptorBindingUniformTexelBufferUpdateAfterBind = VK_TRUE,
+        .descriptorBindingStorageTexelBufferUpdateAfterBind = VK_TRUE,
+        .descriptorBindingUpdateUnusedWhilePending = VK_TRUE,
     };
     const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extendedDynamicState = {
         .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT,
-        .pNext = (void*)&separateDsLayouts,
+        .pNext = (void*)&vk12DeviceFeatures,
         .extendedDynamicState = VK_TRUE,
     };
     const VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT demoteToHelperInvocation = {
@@ -296,13 +372,42 @@ GR_RESULT grCreateDevice(
         .multiViewport = VK_TRUE,
         .samplerAnisotropy = VK_TRUE,
         .fragmentStoresAndAtomics = VK_TRUE,
+        .shaderInt64 = VK_TRUE,//TODO: try to fallback to 32 bit version if not present
     };
 
+    unsigned extensionCount = 0;
+    if (vki.vkEnumerateDeviceExtensionProperties(grPhysicalGpu->physicalDevice, NULL, &extensionCount, NULL) != VK_SUCCESS) {
+        LOGE("vkEnumerateDeviceExtensionProperties failed\n");
+        res = GR_ERROR_INITIALIZATION_FAILED;
+        goto bail;
+    }
+    VkExtensionProperties* extensionProperties = (VkExtensionProperties*)malloc(sizeof(VkExtensionProperties) * extensionCount);
+    if (extensionProperties == NULL) {
+        res = GR_ERROR_INITIALIZATION_FAILED;
+        goto bail;
+    }
+    if (vki.vkEnumerateDeviceExtensionProperties(grPhysicalGpu->physicalDevice, NULL, &extensionCount, extensionProperties) != VK_SUCCESS) {
+        LOGE("vkEnumerateDeviceExtensionProperties failed\n");
+        res = GR_ERROR_INITIALIZATION_FAILED;
+        goto bail;
+    }
     const char *deviceExtensions[] = {
         VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME,
         VK_EXT_SHADER_DEMOTE_TO_HELPER_INVOCATION_EXTENSION_NAME,
         VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+        VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME,
+        NULL,
     };
+    unsigned deviceExtensionCount = 4;// required extensions
+    bool pushDescriptorsSupported = false;
+    for (unsigned i = 0; i < extensionCount; ++i) {
+        if (strcmp(extensionProperties[i].extensionName, VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME) == 0) {
+            deviceExtensions[deviceExtensionCount++] = VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME;
+            pushDescriptorsSupported = true;
+            LOGT("push descriptor set is supported\n");
+            break;
+        }
+    }
 
     const VkDeviceCreateInfo createInfo = {
         .sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
@@ -312,7 +417,7 @@ GR_RESULT grCreateDevice(
         .pQueueCreateInfos = queueCreateInfos,
         .enabledLayerCount = 0,
         .ppEnabledLayerNames = NULL,
-        .enabledExtensionCount = COUNT_OF(deviceExtensions),
+        .enabledExtensionCount = deviceExtensionCount,
         .ppEnabledExtensionNames = deviceExtensions,
         .pEnabledFeatures = &deviceFeatures,
     };
@@ -337,7 +442,228 @@ GR_RESULT grCreateDevice(
     VkPhysicalDeviceMemoryProperties memoryProperties;
     vki.vkGetPhysicalDeviceMemoryProperties(grPhysicalGpu->physicalDevice, &memoryProperties);
 
+    unsigned descriptorCount = 10240;
+    const VkDescriptorSetLayoutBinding globalLayoutBindings[] = {
+        {
+            .binding = 0,
+            .descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,
+            .descriptorCount = descriptorCount,
+            .stageFlags = VK_SHADER_STAGE_ALL,
+            .pImmutableSamplers = NULL,
+        },
+        {
+            .binding = 1,
+            .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER,
+            .descriptorCount = descriptorCount,
+            .stageFlags = VK_SHADER_STAGE_ALL,
+            .pImmutableSamplers = NULL,
+        },
+        {
+            .binding = 2,
+            .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+            .descriptorCount = descriptorCount,
+            .stageFlags = VK_SHADER_STAGE_ALL,
+            .pImmutableSamplers = NULL,
+        },
+        {
+            .binding = 3,
+            .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+            .descriptorCount = descriptorCount,
+            .stageFlags = VK_SHADER_STAGE_ALL,
+            .pImmutableSamplers = NULL,
+        },
+        {
+            .binding = 4,
+            .descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
+            .descriptorCount = descriptorCount,
+            .stageFlags = VK_SHADER_STAGE_ALL,
+            .pImmutableSamplers = NULL,
+        },
+        {
+            .binding = 5,
+            .descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER,
+            .descriptorCount = descriptorCount,
+            .stageFlags = VK_SHADER_STAGE_ALL,
+            .pImmutableSamplers = NULL,
+        }
+    };
+
+    const VkDescriptorPoolSize poolSizes[] = {
+        {
+            .type = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,
+            .descriptorCount = descriptorCount,
+        },
+        {
+            .type = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER,
+            .descriptorCount = descriptorCount,
+        },
+        {
+            .type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
+            .descriptorCount = descriptorCount,
+        },
+        {
+            .type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+            .descriptorCount = descriptorCount,
+        },
+        {
+            .type = VK_DESCRIPTOR_TYPE_SAMPLER,
+            .descriptorCount = descriptorCount,
+        },
+        {
+            .type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+            .descriptorCount = descriptorCount,
+        }
+    };
+    const VkDescriptorBindingFlags globalLayoutBindingFlags[] = {
+        VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT,
+        VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT,
+        VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT,
+        VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT,
+        VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT,
+        VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT,
+    };
+    const VkDescriptorSetLayoutBindingFlagsCreateInfo layoutFlags = {
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO,
+        .pNext = NULL,
+        .bindingCount = COUNT_OF(globalLayoutBindingFlags),
+        .pBindingFlags = globalLayoutBindingFlags,
+    };
+    const VkDescriptorSetLayoutCreateInfo layoutCreateInfo = {
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
+        .pNext = &layoutFlags,
+        .flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT | VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT,
+        .bindingCount = COUNT_OF(globalLayoutBindings),
+        .pBindings = globalLayoutBindings,
+    };
+    const VkDescriptorPoolCreateInfo poolCreateInfo = {
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+        .pNext = NULL,
+        .flags = VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT,
+        .maxSets = 1,
+        .poolSizeCount = COUNT_OF(poolSizes),
+        .pPoolSizes = poolSizes,
+    };
+    VkDescriptorSetLayout globalLayout;
+    VkDescriptorSetLayout graphicsDynamicMemoryLayout, computeDynamicMemoryLayout;
+    GrGlobalPipelineLayouts globalPipelineLayouts = {};
+    if (vkd.vkCreateDescriptorSetLayout(vkDevice, &layoutCreateInfo, NULL,
+                                        &globalLayout) != VK_SUCCESS) {
+        LOGE("vkCreateDescriptorSetLayout failed\n");
+        res = GR_ERROR_INITIALIZATION_FAILED;
+        goto bail;
+    }
+
+    const VkDescriptorSetLayoutBinding graphicsDynamicLayoutBindings[] = {
+        {
+            .binding = 0,
+            .descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,
+            .descriptorCount = 1,
+            .stageFlags = VK_SHADER_STAGE_ALL_GRAPHICS,
+            .pImmutableSamplers = NULL,
+        },
+        {
+            .binding = 1,
+            .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER,
+            .descriptorCount = 1,
+            .stageFlags = VK_SHADER_STAGE_ALL_GRAPHICS,
+            .pImmutableSamplers = NULL,
+        },
+        {
+            .binding = 2,
+            .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+            .descriptorCount = 1,
+            .stageFlags = VK_SHADER_STAGE_ALL_GRAPHICS,
+            .pImmutableSamplers = NULL,
+        }
+    };
+    VkDescriptorSetLayoutCreateInfo dynamicMemoryLayoutCreateInfo = {
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
+        .pNext = NULL,
+        .flags = pushDescriptorsSupported ? VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT_KHR : 0,
+        .bindingCount = COUNT_OF(graphicsDynamicLayoutBindings),
+        .pBindings = graphicsDynamicLayoutBindings,
+    };
+
+    if (vkd.vkCreateDescriptorSetLayout(vkDevice, &dynamicMemoryLayoutCreateInfo, NULL, &graphicsDynamicMemoryLayout) != VK_SUCCESS) {
+        LOGE("vkCreateDescriptorSetLayout failed\n");
+        res = GR_ERROR_INITIALIZATION_FAILED;
+        goto bail;
+    }
+
+    const VkDescriptorSetLayoutBinding computeLayoutBindings[] = {
+        {
+            .binding = 0,
+            .descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,
+            .descriptorCount = 1,
+            .stageFlags = VK_SHADER_STAGE_COMPUTE_BIT,
+            .pImmutableSamplers = NULL,
+        },
+        {
+            .binding = 1,
+            .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER,
+            .descriptorCount = 1,
+            .stageFlags = VK_SHADER_STAGE_COMPUTE_BIT,
+            .pImmutableSamplers = NULL,
+        },
+        {
+            .binding = 2,
+            .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+            .descriptorCount = 1,
+            .stageFlags = VK_SHADER_STAGE_COMPUTE_BIT,
+            .pImmutableSamplers = NULL,
+        }
+    };
+    dynamicMemoryLayoutCreateInfo.pBindings = computeLayoutBindings;
+    if (vkd.vkCreateDescriptorSetLayout(vkDevice, &dynamicMemoryLayoutCreateInfo, NULL, &computeDynamicMemoryLayout) != VK_SUCCESS) {
+        LOGE("vkCreateDescriptorSetLayout failed\n");
+        res = GR_ERROR_INITIALIZATION_FAILED;
+        goto bail;
+    }
+
+    if (getVkPipelineLayout(vkDevice, &vkd, globalLayout, graphicsDynamicMemoryLayout, computeDynamicMemoryLayout, &globalPipelineLayouts) != VK_SUCCESS) {
+        LOGE("failed to create pipeline layouts\n");
+        res = GR_ERROR_INITIALIZATION_FAILED;
+        goto bail;
+    }
+
+    VkDescriptorPool globalPool;
+    if (vkd.vkCreateDescriptorPool(vkDevice, &poolCreateInfo, NULL,
+                                   &globalPool) != VK_SUCCESS) {
+        LOGE("vkCreateDescriptorPool failed\n");
+        res = GR_ERROR_INITIALIZATION_FAILED;
+        goto bail;
+    }
+
+    const VkDescriptorSetAllocateInfo allocateInfo = {
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+        .pNext = NULL,
+        .descriptorPool = globalPool,
+        .descriptorSetCount = 1,
+        .pSetLayouts = &globalLayout,
+    };
+    VkDescriptorSet globalDescSet;
+    if (vkd.vkAllocateDescriptorSets(vkDevice, &allocateInfo,
+                                   &globalDescSet) != VK_SUCCESS) {
+        LOGE("vkCreateDescriptorPool failed\n");
+        res = GR_ERROR_INITIALIZATION_FAILED;
+        goto bail;
+    }
+
     GrDevice* grDevice = malloc(sizeof(GrDevice));
+    if (grDevice == NULL) {
+        res = GR_ERROR_INITIALIZATION_FAILED;
+        goto bail;
+    }
+    bool* descriptorHandleBuffer = (bool*)malloc(sizeof(bool) * 3 * descriptorCount);
+    if (descriptorHandleBuffer == NULL) {
+        res = GR_ERROR_INITIALIZATION_FAILED;
+        goto bail;
+    }
+    memset(descriptorHandleBuffer, 0, sizeof(bool) * 3 * descriptorCount);
+    if (descriptorHandleBuffer == NULL) {
+        res = GR_ERROR_INITIALIZATION_FAILED;
+        goto bail;
+    }
     *grDevice = (GrDevice) {
         .grBaseObj = { GR_OBJ_TYPE_DEVICE },
         .vkd = vkd,
@@ -346,18 +672,63 @@ GR_RESULT grCreateDevice(
         .memoryProperties = memoryProperties,
         .universalQueueIndex = universalQueueIndex,
         .computeQueueIndex = computeQueueIndex,
+        .globalDescriptorSet = {
+            .descriptorTableLayout = globalLayout,
+            .graphicsDynamicMemoryLayout = graphicsDynamicMemoryLayout,
+            .computeDynamicMemoryLayout = computeDynamicMemoryLayout,
+            .descriptorPool = globalPool,
+            .descriptorTable = globalDescSet,
+            .samplers = descriptorHandleBuffer,
+            .samplerPtr = descriptorHandleBuffer,
+            .bufferViews = descriptorHandleBuffer + descriptorCount,
+            .bufferViewPtr = descriptorHandleBuffer + descriptorCount,//TODO: support mutable descriptors
+            .images = descriptorHandleBuffer + 2 * descriptorCount,
+            .imagePtr = descriptorHandleBuffer + 2 * descriptorCount,
+            .descriptorCount = descriptorCount,
+        },
+        .pipelineLayouts = globalPipelineLayouts,
+        .vDescriptorSetMemoryTypeIndex = 2,
+        .pushDescriptorSetSupported = pushDescriptorsSupported,
     };
 
+    grDevice->vDescriptorSetMemoryTypeIndex = getVirtualDescriptorSetBufferMemoryType(&grDevice->memoryProperties);
     *pDevice = (GR_DEVICE)grDevice;
 
 bail:
     for (int i = 0; i < pCreateInfo->queueRecordCount; i++) {
         free((void*)queueCreateInfos[i].pQueuePriorities);
     }
-    free(queueCreateInfos);
-
+    if (queueCreateInfos != NULL) {
+        free(queueCreateInfos);
+    }
+    if (extensionProperties != NULL) {
+        free(extensionProperties);
+    }
     if (res != GR_SUCCESS) {
-        vkd.vkDestroyDevice(vkDevice, NULL);
+        if (globalPipelineLayouts.graphicsPipelineLayout != VK_NULL_HANDLE) {
+            vkd.vkDestroyPipelineLayout(vkDevice, globalPipelineLayouts.graphicsPipelineLayout, NULL);
+        }
+        if (globalPipelineLayouts.computePipelineLayout != VK_NULL_HANDLE) {
+            vkd.vkDestroyPipelineLayout(vkDevice, globalPipelineLayouts.computePipelineLayout, NULL);
+        }
+        if (graphicsDynamicMemoryLayout != VK_NULL_HANDLE) {
+            vkd.vkDestroyDescriptorSetLayout(vkDevice, graphicsDynamicMemoryLayout, NULL);
+        }
+        if (computeDynamicMemoryLayout != VK_NULL_HANDLE) {
+            vkd.vkDestroyDescriptorSetLayout(vkDevice, computeDynamicMemoryLayout, NULL);
+        }
+        if (globalLayout != VK_NULL_HANDLE) {
+            vkd.vkDestroyDescriptorSetLayout(vkDevice, globalLayout, NULL);
+        }
+        if (globalPool != VK_NULL_HANDLE) {
+            vkd.vkDestroyDescriptorPool(vkDevice, globalPool, NULL);
+        }
+        if (vkDevice != VK_NULL_HANDLE) {
+            vkd.vkDestroyDevice(vkDevice, NULL);
+        }
+        if (descriptorHandleBuffer != NULL) {
+            free(descriptorHandleBuffer);
+        }
     }
 
     return res;
@@ -374,7 +745,27 @@ GR_RESULT grDestroyDevice(
     } else if (GET_OBJ_TYPE(grDevice) != GR_OBJ_TYPE_DEVICE) {
         return GR_ERROR_INVALID_OBJECT_TYPE;
     }
-
+    if (grDevice->pipelineLayouts.graphicsPipelineLayout != VK_NULL_HANDLE) {
+        VKD.vkDestroyPipelineLayout(grDevice->device, grDevice->pipelineLayouts.graphicsPipelineLayout, NULL);
+    }
+    if (grDevice->pipelineLayouts.computePipelineLayout != VK_NULL_HANDLE) {
+        VKD.vkDestroyPipelineLayout(grDevice->device, grDevice->pipelineLayouts.computePipelineLayout, NULL);
+    }
+    if (grDevice->globalDescriptorSet.graphicsDynamicMemoryLayout != VK_NULL_HANDLE) {
+        VKD.vkDestroyDescriptorSetLayout(grDevice->device, grDevice->globalDescriptorSet.graphicsDynamicMemoryLayout, NULL);
+    }
+    if (grDevice->globalDescriptorSet.computeDynamicMemoryLayout != VK_NULL_HANDLE) {
+        VKD.vkDestroyDescriptorSetLayout(grDevice->device, grDevice->globalDescriptorSet.computeDynamicMemoryLayout, NULL);
+    }
+    if (grDevice->globalDescriptorSet.descriptorTableLayout != VK_NULL_HANDLE) {
+        VKD.vkDestroyDescriptorSetLayout(grDevice->device, grDevice->globalDescriptorSet.descriptorTableLayout, NULL);
+    }
+    if (grDevice->globalDescriptorSet.descriptorPool != VK_NULL_HANDLE) {
+        VKD.vkDestroyDescriptorPool(grDevice->device, grDevice->globalDescriptorSet.descriptorPool, NULL);
+    }
+    if (grDevice->globalDescriptorSet.samplers != NULL) {
+        free(grDevice->globalDescriptorSet.samplers); // single allocation, samplers are first in the buffer
+    }
     VKD.vkDestroyDevice(grDevice->device, NULL);
     free(grDevice);
 

--- a/src/mantle/mantle_object.h
+++ b/src/mantle/mantle_object.h
@@ -189,11 +189,11 @@ typedef struct _GrGlobalDescriptorSet {
     VkDescriptorPool descriptorPool;
     VkDescriptorSet descriptorTable;
     bool* samplers;
-    bool* samplerPtr;
+    unsigned samplerIndex;
     bool* bufferViews;
-    bool* bufferViewPtr;
+    unsigned bufferViewIndex;
     bool* images;
-    bool* imagePtr;
+    unsigned imageIndex;
     unsigned descriptorCount;
 } GrGlobalDescriptorSet;
 

--- a/src/mantle/mantle_object_man.c
+++ b/src/mantle/mantle_object_man.c
@@ -16,10 +16,19 @@ GR_RESULT grDestroyObject(
     switch (grObject->grObjType) {
     case GR_OBJ_TYPE_COMMAND_BUFFER: {
         GrCmdBuffer* grCmdBuffer = (GrCmdBuffer*)grObject;
-
         VKD.vkDestroyCommandPool(grDevice->device, grCmdBuffer->commandPool, NULL);
         grCmdBufferResetState(grCmdBuffer);
     }   break;
+    case GR_OBJ_TYPE_SHADER: {
+        GrShader* grShader = (GrShader*)grObject;
+        free(grShader->code);
+    } break;
+    case GR_OBJ_TYPE_PIPELINE: {
+        GrPipeline* grPipeline = (GrPipeline*)grObject;
+        for (unsigned i = 0; i < grPipeline->pipelineSlotCount; ++i) {
+            VKD.vkDestroyPipeline(grDevice->device, grPipeline->pipelineSlots[i].pipeline, NULL);
+        }
+    } break;
     case GR_OBJ_TYPE_COLOR_TARGET_VIEW: {
         GrColorTargetView* grColorTargetView = (GrColorTargetView*)grObject;
 

--- a/src/mantle/mantle_shader_pipeline.c
+++ b/src/mantle/mantle_shader_pipeline.c
@@ -512,7 +512,9 @@ GR_RESULT grCreateGraphicsPipeline(
 
     GrPipeline* grPipeline = malloc(sizeof(GrPipeline));
     if (grPipeline == NULL) {
-        return GR_ERROR_OUT_OF_MEMORY;
+        LOGE("failed to allocate memory for GrPipeline\n");
+        res = GR_ERROR_OUT_OF_MEMORY;
+        goto bail;
     }
     *grPipeline = (GrPipeline) {
         .grObj = { GR_OBJ_TYPE_PIPELINE, grDevice },
@@ -530,6 +532,11 @@ GR_RESULT grCreateGraphicsPipeline(
     return GR_SUCCESS;
 
 bail:
+    for (unsigned i = 0; i < stageCount;++i) {
+        if (shaderStageCreateInfo[i].module != VK_NULL_HANDLE) {
+            VKD.vkDestroyShaderModule(grDevice->device, shaderStageCreateInfo[i].module, NULL);
+        }
+    }
     if (renderPass != VK_NULL_HANDLE) {
         VKD.vkDestroyRenderPass(grDevice->device, renderPass, NULL);
     }

--- a/src/mantle/vulkan_loader.c
+++ b/src/mantle/vulkan_loader.c
@@ -172,6 +172,7 @@ void vulkanLoaderDeviceInit(
     LOAD_VULKAN_DEV_FN(vkd, device, vkGetBufferMemoryRequirements);
     LOAD_VULKAN_DEV_FN(vkd, device, vkGetBufferMemoryRequirements2);
     LOAD_VULKAN_DEV_FN(vkd, device, vkGetDeviceMemoryCommitment);
+    LOAD_VULKAN_DEV_FN(vkd, device, vkGetBufferDeviceAddress);
     LOAD_VULKAN_DEV_FN(vkd, device, vkGetDeviceQueue);
     LOAD_VULKAN_DEV_FN(vkd, device, vkGetEventStatus);
     LOAD_VULKAN_DEV_FN(vkd, device, vkGetFenceStatus);
@@ -224,5 +225,9 @@ void vulkanLoaderDeviceInit(
     LOAD_VULKAN_DEV_FN(vkd, device, vkCmdSetStencilOpEXT);
     LOAD_VULKAN_DEV_FN(vkd, device, vkCmdSetStencilTestEnableEXT);
     LOAD_VULKAN_DEV_FN(vkd, device, vkCmdSetViewportWithCountEXT);
+#endif
+
+#ifdef VK_KHR_push_descriptor
+    LOAD_VULKAN_DEV_FN(vkd, device, vkCmdPushDescriptorSetKHR);
 #endif
 }

--- a/src/mantle/vulkan_loader.h
+++ b/src/mantle/vulkan_loader.h
@@ -1,11 +1,14 @@
 #ifndef VULKAN_LOADER_H_
 #define VULKAN_LOADER_H_
-
+#if defined(_WIN64) || defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #include "windows.h"
+#endif
 #define VK_NO_PROTOTYPES
 #include "vulkan/vulkan.h"
+#if defined(_WIN64) || defined(_WIN32)
 #include "vulkan/vulkan_win32.h"
+#endif
 
 #define VULKAN_FN(name) \
     PFN_##name name
@@ -165,6 +168,7 @@ typedef struct _VULKAN_DEVICE {
     VULKAN_FN(vkGetPipelineCacheData);
     VULKAN_FN(vkGetQueryPoolResults);
     VULKAN_FN(vkGetRenderAreaGranularity);
+    VULKAN_FN(vkGetBufferDeviceAddress);
     VULKAN_FN(vkInvalidateMappedMemoryRanges);
     VULKAN_FN(vkMapMemory);
     VULKAN_FN(vkMergePipelineCaches);
@@ -206,6 +210,10 @@ typedef struct _VULKAN_DEVICE {
     VULKAN_FN(vkCmdSetStencilOpEXT);
     VULKAN_FN(vkCmdSetStencilTestEnableEXT);
     VULKAN_FN(vkCmdSetViewportWithCountEXT);
+#endif
+
+#ifdef VK_KHR_push_descriptor
+    VULKAN_FN(vkCmdPushDescriptorSetKHR);
 #endif
 } VULKAN_DEVICE;
 


### PR DESCRIPTION
I've re-implemented descriptor sets logic to properly support nested descriptor sets and dynamic memory binding.

To properly support nested descriptor sets I've added big global descriptor set with 10k indices for each resources, and made `GrDescriptorSet` a buffer with indices or device pointers to another `GrDescriptorSet`s. This allows to easily bind virtual descriptor sets with specified offsets without calling unnecessary vkUpdateDescriptorSets on every `GrDescriptorSet` update.

Also moved amdilc shader translation to `grCreate*Pipeline` functions to properly assign resource index or resource loading to specified descriptor slots.