### PR TITLE
Add GR_STDCALL to all mantle calls for proper 32-bit support

### DIFF
--- a/include/mantle/mantle.h
+++ b/include/mantle/mantle.h
@@ -10,7 +10,11 @@ extern "C" {
 
 #define MANTLE_HANDLE(name) typedef void* name
 
-#define GR_STDCALL __stdcall
+#if defined(_WIN32)
+  #define GR_STDCALL __stdcall
+#else
+  #define GR_STDCALL
+#endif
 
 // Types
 
@@ -1275,47 +1279,47 @@ typedef struct _GR_VIRTUAL_MEMORY_REMAP_RANGE
 
 // Initialization and Device Functions
 
-GR_RESULT grInitAndEnumerateGpus(
+GR_RESULT GR_STDCALL grInitAndEnumerateGpus(
     const GR_APPLICATION_INFO* pAppInfo,
     const GR_ALLOC_CALLBACKS* pAllocCb,
     GR_UINT* pGpuCount,
     GR_PHYSICAL_GPU gpus[GR_MAX_PHYSICAL_GPUS]);
 
-GR_RESULT grGetGpuInfo(
+GR_RESULT GR_STDCALL grGetGpuInfo(
     GR_PHYSICAL_GPU gpu,
     GR_ENUM infoType,
     GR_SIZE* pDataSize,
     GR_VOID* pData);
 
-GR_RESULT grCreateDevice(
+GR_RESULT GR_STDCALL grCreateDevice(
     GR_PHYSICAL_GPU gpu,
     const GR_DEVICE_CREATE_INFO* pCreateInfo,
     GR_DEVICE* pDevice);
 
-GR_RESULT grDestroyDevice(
+GR_RESULT GR_STDCALL grDestroyDevice(
     GR_DEVICE device);
 
 // Extension Discovery Functions
 
-GR_RESULT grGetExtensionSupport(
+GR_RESULT GR_STDCALL grGetExtensionSupport(
     GR_PHYSICAL_GPU gpu,
     const GR_CHAR* pExtName);
 
 // Queue Functions
 
-GR_RESULT grGetDeviceQueue(
+GR_RESULT GR_STDCALL grGetDeviceQueue(
     GR_DEVICE device,
     GR_ENUM queueType,
     GR_UINT queueId,
     GR_QUEUE* pQueue);
 
-GR_RESULT grQueueWaitIdle(
+GR_RESULT GR_STDCALL grQueueWaitIdle(
     GR_QUEUE queue);
 
-GR_RESULT grDeviceWaitIdle(
+GR_RESULT GR_STDCALL grDeviceWaitIdle(
     GR_DEVICE device);
 
-GR_RESULT grQueueSubmit(
+GR_RESULT GR_STDCALL grQueueSubmit(
     GR_QUEUE queue,
     GR_UINT cmdBufferCount,
     const GR_CMD_BUFFER* pCmdBuffers,
@@ -1323,45 +1327,45 @@ GR_RESULT grQueueSubmit(
     const GR_MEMORY_REF* pMemRefs,
     GR_FENCE fence);
 
-GR_RESULT grQueueSetGlobalMemReferences(
+GR_RESULT GR_STDCALL grQueueSetGlobalMemReferences(
     GR_QUEUE queue,
     GR_UINT memRefCount,
     const GR_MEMORY_REF* pMemRefs);
 
 // Memory Management Functions
 
-GR_RESULT grGetMemoryHeapCount(
+GR_RESULT GR_STDCALL grGetMemoryHeapCount(
     GR_DEVICE device,
     GR_UINT* pCount);
 
-GR_RESULT grGetMemoryHeapInfo(
+GR_RESULT GR_STDCALL grGetMemoryHeapInfo(
     GR_DEVICE device,
     GR_UINT heapId,
     GR_ENUM infoType,
     GR_SIZE* pDataSize,
     GR_VOID* pData);
 
-GR_RESULT grAllocMemory(
+GR_RESULT GR_STDCALL grAllocMemory(
     GR_DEVICE device,
     const GR_MEMORY_ALLOC_INFO* pAllocInfo,
     GR_GPU_MEMORY* pMem);
 
-GR_RESULT grFreeMemory(
+GR_RESULT GR_STDCALL grFreeMemory(
     GR_GPU_MEMORY mem);
 
-GR_RESULT grSetMemoryPriority(
+GR_RESULT GR_STDCALL grSetMemoryPriority(
     GR_GPU_MEMORY mem,
     GR_ENUM priority);
 
-GR_RESULT grMapMemory(
+GR_RESULT GR_STDCALL grMapMemory(
     GR_GPU_MEMORY mem,
     GR_FLAGS flags,
     GR_VOID** ppData);
 
-GR_RESULT grUnmapMemory(
+GR_RESULT GR_STDCALL grUnmapMemory(
     GR_GPU_MEMORY mem);
 
-GR_RESULT grRemapVirtualMemoryPages(
+GR_RESULT GR_STDCALL grRemapVirtualMemoryPages(
     GR_DEVICE device,
     GR_UINT rangeCount,
     const GR_VIRTUAL_MEMORY_REMAP_RANGE* pRanges,
@@ -1370,7 +1374,7 @@ GR_RESULT grRemapVirtualMemoryPages(
     GR_UINT postSignalSemaphoreCount,
     const GR_QUEUE_SEMAPHORE* pPostSignalSemaphores);
 
-GR_RESULT grPinSystemMemory(
+GR_RESULT GR_STDCALL grPinSystemMemory(
     GR_DEVICE device,
     const GR_VOID* pSysMem,
     GR_SIZE memSize,
@@ -1378,86 +1382,86 @@ GR_RESULT grPinSystemMemory(
 
 // Generic API Object Management functions
 
-GR_RESULT grDestroyObject(
+GR_RESULT GR_STDCALL grDestroyObject(
     GR_OBJECT object);
 
-GR_RESULT grGetObjectInfo(
+GR_RESULT GR_STDCALL grGetObjectInfo(
     GR_BASE_OBJECT object,
     GR_ENUM infoType,
     GR_SIZE* pDataSize,
     GR_VOID* pData);
 
-GR_RESULT grBindObjectMemory(
+GR_RESULT GR_STDCALL grBindObjectMemory(
     GR_OBJECT object,
     GR_GPU_MEMORY mem,
     GR_GPU_SIZE offset);
 
 // Image and Sample Functions
 
-GR_RESULT grGetFormatInfo(
+GR_RESULT GR_STDCALL grGetFormatInfo(
     GR_DEVICE device,
     GR_FORMAT format,
     GR_ENUM infoType,
     GR_SIZE* pDataSize,
     GR_VOID* pData);
 
-GR_RESULT grCreateImage(
+GR_RESULT GR_STDCALL grCreateImage(
     GR_DEVICE device,
     const GR_IMAGE_CREATE_INFO* pCreateInfo,
     GR_IMAGE* pImage);
 
-GR_RESULT grGetImageSubresourceInfo(
+GR_RESULT GR_STDCALL grGetImageSubresourceInfo(
     GR_IMAGE image,
     const GR_IMAGE_SUBRESOURCE* pSubresource,
     GR_ENUM infoType,
     GR_SIZE* pDataSize,
     GR_VOID* pData);
 
-GR_RESULT grCreateSampler(
+GR_RESULT GR_STDCALL grCreateSampler(
     GR_DEVICE device,
     const GR_SAMPLER_CREATE_INFO* pCreateInfo,
     GR_SAMPLER* pSampler);
 
 // Image View Functions
 
-GR_RESULT grCreateImageView(
+GR_RESULT GR_STDCALL grCreateImageView(
     GR_DEVICE device,
     const GR_IMAGE_VIEW_CREATE_INFO* pCreateInfo,
     GR_IMAGE_VIEW* pView);
 
-GR_RESULT grCreateColorTargetView(
+GR_RESULT GR_STDCALL grCreateColorTargetView(
     GR_DEVICE device,
     const GR_COLOR_TARGET_VIEW_CREATE_INFO* pCreateInfo,
     GR_COLOR_TARGET_VIEW* pView);
 
-GR_RESULT grCreateDepthStencilView(
+GR_RESULT GR_STDCALL grCreateDepthStencilView(
     GR_DEVICE device,
     const GR_DEPTH_STENCIL_VIEW_CREATE_INFO* pCreateInfo,
     GR_DEPTH_STENCIL_VIEW* pView);
 
 // Shader and Pipeline Functions
 
-GR_RESULT grCreateShader(
+GR_RESULT GR_STDCALL grCreateShader(
     GR_DEVICE device,
     const GR_SHADER_CREATE_INFO* pCreateInfo,
     GR_SHADER* pShader);
 
-GR_RESULT grCreateGraphicsPipeline(
+GR_RESULT GR_STDCALL grCreateGraphicsPipeline(
     GR_DEVICE device,
     const GR_GRAPHICS_PIPELINE_CREATE_INFO* pCreateInfo,
     GR_PIPELINE* pPipeline);
 
-GR_RESULT grCreateComputePipeline(
+GR_RESULT GR_STDCALL grCreateComputePipeline(
     GR_DEVICE device,
     const GR_COMPUTE_PIPELINE_CREATE_INFO* pCreateInfo,
     GR_PIPELINE* pPipeline);
 
-GR_RESULT grStorePipeline(
+GR_RESULT GR_STDCALL grStorePipeline(
     GR_PIPELINE pipeline,
     GR_SIZE* pDataSize,
     GR_VOID* pData);
 
-GR_RESULT grLoadPipeline(
+GR_RESULT GR_STDCALL grLoadPipeline(
     GR_DEVICE device,
     GR_SIZE dataSize,
     const GR_VOID* pData,
@@ -1465,7 +1469,7 @@ GR_RESULT grLoadPipeline(
 
 // Descriptor Set Functions
 
-GR_RESULT grCreateDescriptorSet(
+GR_RESULT GR_STDCALL grCreateDescriptorSet(
     GR_DEVICE device,
     const GR_DESCRIPTOR_SET_CREATE_INFO* pCreateInfo,
     GR_DESCRIPTOR_SET* pDescriptorSet);
@@ -1507,110 +1511,110 @@ GR_VOID grClearDescriptorSetSlots(
 
 // State Object Functions
 
-GR_RESULT grCreateViewportState(
+GR_RESULT GR_STDCALL grCreateViewportState(
     GR_DEVICE device,
     const GR_VIEWPORT_STATE_CREATE_INFO* pCreateInfo,
     GR_VIEWPORT_STATE_OBJECT* pState);
 
-GR_RESULT grCreateRasterState(
+GR_RESULT GR_STDCALL grCreateRasterState(
     GR_DEVICE device,
     const GR_RASTER_STATE_CREATE_INFO* pCreateInfo,
     GR_RASTER_STATE_OBJECT* pState);
 
-GR_RESULT grCreateColorBlendState(
+GR_RESULT GR_STDCALL grCreateColorBlendState(
     GR_DEVICE device,
     const GR_COLOR_BLEND_STATE_CREATE_INFO* pCreateInfo,
     GR_COLOR_BLEND_STATE_OBJECT* pState);
 
-GR_RESULT grCreateDepthStencilState(
+GR_RESULT GR_STDCALL grCreateDepthStencilState(
     GR_DEVICE device,
     const GR_DEPTH_STENCIL_STATE_CREATE_INFO* pCreateInfo,
     GR_DEPTH_STENCIL_STATE_OBJECT* pState);
 
-GR_RESULT grCreateMsaaState(
+GR_RESULT GR_STDCALL grCreateMsaaState(
     GR_DEVICE device,
     const GR_MSAA_STATE_CREATE_INFO* pCreateInfo,
     GR_MSAA_STATE_OBJECT* pState);
 
 // Query and Synchronization Functions
 
-GR_RESULT grCreateQueryPool(
+GR_RESULT GR_STDCALL grCreateQueryPool(
     GR_DEVICE device,
     const GR_QUERY_POOL_CREATE_INFO* pCreateInfo,
     GR_QUERY_POOL* pQueryPool);
 
-GR_RESULT grGetQueryPoolResults(
+GR_RESULT GR_STDCALL grGetQueryPoolResults(
     GR_QUERY_POOL queryPool,
     GR_UINT startQuery,
     GR_UINT queryCount,
     GR_SIZE* pDataSize,
     GR_VOID* pData);
 
-GR_RESULT grCreateFence(
+GR_RESULT GR_STDCALL grCreateFence(
     GR_DEVICE device,
     const GR_FENCE_CREATE_INFO* pCreateInfo,
     GR_FENCE* pFence);
 
-GR_RESULT grGetFenceStatus(
+GR_RESULT GR_STDCALL grGetFenceStatus(
     GR_FENCE fence);
 
-GR_RESULT grWaitForFences(
+GR_RESULT GR_STDCALL grWaitForFences(
     GR_DEVICE device,
     GR_UINT fenceCount,
     const GR_FENCE* pFences,
     GR_BOOL waitAll,
     GR_FLOAT timeout);
 
-GR_RESULT grCreateQueueSemaphore(
+GR_RESULT GR_STDCALL grCreateQueueSemaphore(
     GR_DEVICE device,
     const GR_QUEUE_SEMAPHORE_CREATE_INFO* pCreateInfo,
     GR_QUEUE_SEMAPHORE* pSemaphore);
 
-GR_RESULT grSignalQueueSemaphore(
+GR_RESULT GR_STDCALL grSignalQueueSemaphore(
     GR_QUEUE queue,
     GR_QUEUE_SEMAPHORE semaphore);
 
-GR_RESULT grWaitQueueSemaphore(
+GR_RESULT GR_STDCALL grWaitQueueSemaphore(
     GR_QUEUE queue,
     GR_QUEUE_SEMAPHORE semaphore);
 
-GR_RESULT grCreateEvent(
+GR_RESULT GR_STDCALL grCreateEvent(
     GR_DEVICE device,
     const GR_EVENT_CREATE_INFO* pCreateInfo,
     GR_EVENT* pEvent);
 
-GR_RESULT grGetEventStatus(
+GR_RESULT GR_STDCALL grGetEventStatus(
     GR_EVENT event);
 
-GR_RESULT grSetEvent(
+GR_RESULT GR_STDCALL grSetEvent(
     GR_EVENT event);
 
-GR_RESULT grResetEvent(
+GR_RESULT GR_STDCALL grResetEvent(
     GR_EVENT event);
 
 // Multi-Device Management Functions
 
-GR_RESULT grGetMultiGpuCompatibility(
+GR_RESULT GR_STDCALL grGetMultiGpuCompatibility(
     GR_PHYSICAL_GPU gpu0,
     GR_PHYSICAL_GPU gpu1,
     GR_GPU_COMPATIBILITY_INFO* pInfo);
 
-GR_RESULT grOpenSharedMemory(
+GR_RESULT GR_STDCALL grOpenSharedMemory(
     GR_DEVICE device,
     const GR_MEMORY_OPEN_INFO* pOpenInfo,
     GR_GPU_MEMORY* pMem);
 
-GR_RESULT grOpenSharedQueueSemaphore(
+GR_RESULT GR_STDCALL grOpenSharedQueueSemaphore(
     GR_DEVICE device,
     const GR_QUEUE_SEMAPHORE_OPEN_INFO* pOpenInfo,
     GR_QUEUE_SEMAPHORE* pSemaphore);
 
-GR_RESULT grOpenPeerMemory(
+GR_RESULT GR_STDCALL grOpenPeerMemory(
     GR_DEVICE device,
     const GR_PEER_MEMORY_OPEN_INFO* pOpenInfo,
     GR_GPU_MEMORY* pMem);
 
-GR_RESULT grOpenPeerImage(
+GR_RESULT GR_STDCALL grOpenPeerImage(
     GR_DEVICE device,
     const GR_PEER_IMAGE_OPEN_INFO* pOpenInfo,
     GR_IMAGE* pImage,
@@ -1618,19 +1622,19 @@ GR_RESULT grOpenPeerImage(
 
 // Command Buffer Management Functions
 
-GR_RESULT grCreateCommandBuffer(
+GR_RESULT GR_STDCALL grCreateCommandBuffer(
     GR_DEVICE device,
     const GR_CMD_BUFFER_CREATE_INFO* pCreateInfo,
     GR_CMD_BUFFER* pCmdBuffer);
 
-GR_RESULT grBeginCommandBuffer(
+GR_RESULT GR_STDCALL grBeginCommandBuffer(
     GR_CMD_BUFFER cmdBuffer,
     GR_FLAGS flags);
 
-GR_RESULT grEndCommandBuffer(
+GR_RESULT GR_STDCALL grEndCommandBuffer(
     GR_CMD_BUFFER cmdBuffer);
 
-GR_RESULT grResetCommandBuffer(
+GR_RESULT GR_STDCALL grResetCommandBuffer(
     GR_CMD_BUFFER cmdBuffer);
 
 // Command Buffer Building Functions

--- a/include/mantle/mantleDbg.h
+++ b/include/mantle/mantleDbg.h
@@ -100,29 +100,29 @@ GR_RESULT GR_STDCALL grDbgSetValidationLevel(
     GR_DEVICE device,
     GR_ENUM validationLevel);
 
-GR_RESULT grDbgRegisterMsgCallback(
+GR_RESULT GR_STDCALL grDbgRegisterMsgCallback(
     GR_DBG_MSG_CALLBACK_FUNCTION pfnMsgCallback,
     GR_VOID* pUserData);
 
-GR_RESULT grDbgUnregisterMsgCallback(
+GR_RESULT GR_STDCALL grDbgUnregisterMsgCallback(
     GR_DBG_MSG_CALLBACK_FUNCTION pfnMsgCallback);
 
-GR_RESULT grDbgSetMessageFilter(
+GR_RESULT GR_STDCALL grDbgSetMessageFilter(
     GR_DEVICE device,
     GR_ENUM msgCode,
     GR_ENUM filter);
 
-GR_RESULT grDbgSetObjectTag(
+GR_RESULT GR_STDCALL grDbgSetObjectTag(
     GR_BASE_OBJECT object,
     GR_SIZE tagSize,
     const GR_VOID* pTag);
 
-GR_RESULT grDbgSetGlobalOption(
+GR_RESULT GR_STDCALL grDbgSetGlobalOption(
     GR_DBG_GLOBAL_OPTION dbgOption,
     GR_SIZE dataSize,
     const GR_VOID* pData);
 
-GR_RESULT grDbgSetDeviceOption(
+GR_RESULT GR_STDCALL grDbgSetDeviceOption(
     GR_DEVICE device,
     GR_DBG_DEVICE_OPTION dbgOption,
     GR_SIZE dataSize,

--- a/include/mantle/mantleExt.h
+++ b/include/mantle/mantleExt.h
@@ -140,12 +140,12 @@ GR_UINT32 grGetExtensionLibraryVersion();
 
 // Border Color Palette Extension Functions
 
-GR_RESULT grCreateBorderColorPalette(
+GR_RESULT GR_STDCALL grCreateBorderColorPalette(
     GR_DEVICE device,
     const GR_BORDER_COLOR_PALETTE_CREATE_INFO* pCreateInfo,
     GR_BORDER_COLOR_PALETTE* pPalette);
 
-GR_RESULT grUpdateBorderColorPalette(
+GR_RESULT GR_STDCALL grUpdateBorderColorPalette(
     GR_BORDER_COLOR_PALETTE palette,
     GR_UINT firstEntry,
     GR_UINT entryCount,
@@ -158,19 +158,19 @@ GR_VOID grCmdBindBorderColorPalette(
 
 // Advanced Multisampling Extnension Functions
 
-GR_RESULT grCreateAdvancedMsaaState(
+GR_RESULT GR_STDCALL grCreateAdvancedMsaaState(
     GR_DEVICE device,
     const GR_ADVANCED_MSAA_STATE_CREATE_INFO* pCreateInfo,
     GR_MSAA_STATE_OBJECT* pState);
 
-GR_RESULT grCreateFmaskImageView(
+GR_RESULT GR_STDCALL grCreateFmaskImageView(
     GR_DEVICE device,
     const GR_FMASK_IMAGE_VIEW_CREATE_INFO* pCreateInfo,
     GR_IMAGE_VIEW* pView);
 
 // Copy Occlusion Query Data Extension Functions
 
-GR_RESULT grCmdCopyOcclusionData(
+GR_RESULT GR_STDCALL grCmdCopyOcclusionData(
     GR_CMD_BUFFER cmdBuffer,
     GR_QUERY_POOL queryPool,
     GR_UINT startQuery,
@@ -227,99 +227,99 @@ GR_VOID grCmdEndWhile(
 
 // Timer Queue Extension Functions
 
-GR_RESULT grQueueDelay(
+GR_RESULT GR_STDCALL grQueueDelay(
     GR_QUEUE queue,
     GR_FLOAT delay);
 
-GR_RESULT grCalibrateGpuTimestamp(
+GR_RESULT GR_STDCALL grCalibrateGpuTimestamp(
     GR_DEVICE device,
     GR_GPU_TIMESTAMP_CALIBRATION* pCalibrationData);
 
 // Undocumented Functions
 
-GR_RESULT grAddEmulatedPrivateDisplay();
+GR_RESULT GR_STDCALL grAddEmulatedPrivateDisplay();
 
-GR_RESULT grAddPerfExperimentCounter();
+GR_RESULT GR_STDCALL grAddPerfExperimentCounter();
 
-GR_RESULT grAddPerfExperimentTrace();
+GR_RESULT GR_STDCALL grAddPerfExperimentTrace();
 
-GR_RESULT grBlankPrivateDisplay();
+GR_RESULT GR_STDCALL grBlankPrivateDisplay();
 
-GR_RESULT grCmdBeginPerfExperiment();
+GR_RESULT GR_STDCALL grCmdBeginPerfExperiment();
 
-GR_RESULT grCmdBindUserData();
+GR_RESULT GR_STDCALL grCmdBindUserData();
 
-GR_RESULT grCmdCopyRegisterToMemory();
+GR_RESULT GR_STDCALL grCmdCopyRegisterToMemory();
 
-GR_RESULT grCmdDispatchOffset();
+GR_RESULT GR_STDCALL grCmdDispatchOffset();
 
-GR_RESULT grCmdDispatchOffsetIndirect();
+GR_RESULT GR_STDCALL grCmdDispatchOffsetIndirect();
 
-GR_RESULT grCmdEndPerfExperiment();
+GR_RESULT GR_STDCALL grCmdEndPerfExperiment();
 
-GR_RESULT grCmdInsertTraceMarker();
+GR_RESULT GR_STDCALL grCmdInsertTraceMarker();
 
-GR_RESULT grCmdWaitMemoryValue();
+GR_RESULT GR_STDCALL grCmdWaitMemoryValue();
 
-GR_RESULT grCmdWaitRegisterValue();
+GR_RESULT GR_STDCALL grCmdWaitRegisterValue();
 
-GR_RESULT grCreatePerfExperiment();
+GR_RESULT GR_STDCALL grCreatePerfExperiment();
 
-GR_RESULT grCreatePrivateDisplayImage();
+GR_RESULT GR_STDCALL grCreatePrivateDisplayImage();
 
-GR_RESULT grCreateVirtualDisplay();
+GR_RESULT GR_STDCALL grCreateVirtualDisplay();
 
-GR_RESULT grDestroyVirtualDisplay();
+GR_RESULT GR_STDCALL grDestroyVirtualDisplay();
 
-GR_RESULT grDisablePrivateDisplay();
+GR_RESULT GR_STDCALL grDisablePrivateDisplay();
 
-GR_RESULT grEnablePrivateDisplay();
+GR_RESULT GR_STDCALL grEnablePrivateDisplay();
 
-GR_RESULT grEnablePrivateDisplayAudio();
+GR_RESULT GR_STDCALL grEnablePrivateDisplayAudio();
 
-GR_RESULT grFinalizePerfExperiment();
+GR_RESULT GR_STDCALL grFinalizePerfExperiment();
 
-GR_RESULT grGetPrivateDisplayScanLine();
+GR_RESULT GR_STDCALL grGetPrivateDisplayScanLine();
 
-GR_RESULT grGetPrivateDisplays();
+GR_RESULT GR_STDCALL grGetPrivateDisplays();
 
-GR_RESULT grGetVirtualDisplayProperties();
+GR_RESULT GR_STDCALL grGetVirtualDisplayProperties();
 
-GR_RESULT grOpenExternalSharedPrivateDisplayImage();
+GR_RESULT GR_STDCALL grOpenExternalSharedPrivateDisplayImage();
 
-GR_RESULT grPrivateDisplayPresent();
+GR_RESULT GR_STDCALL grPrivateDisplayPresent();
 
-GR_RESULT grQueueDelayAfterVsync();
+GR_RESULT GR_STDCALL grQueueDelayAfterVsync();
 
-GR_RESULT grQueueMigrateObjects();
+GR_RESULT GR_STDCALL grQueueMigrateObjects();
 
-GR_RESULT grQueueSetExecutionPriority();
+GR_RESULT GR_STDCALL grQueueSetExecutionPriority();
 
-GR_RESULT grRegisterPowerEvent();
+GR_RESULT GR_STDCALL grRegisterPowerEvent();
 
-GR_RESULT grRegisterPrivateDisplayEvent();
+GR_RESULT GR_STDCALL grRegisterPrivateDisplayEvent();
 
-GR_RESULT grRemoveEmulatedPrivateDisplay();
+GR_RESULT GR_STDCALL grRemoveEmulatedPrivateDisplay();
 
-GR_RESULT grSetEventAfterVsync();
+GR_RESULT GR_STDCALL grSetEventAfterVsync();
 
-GR_RESULT grSetPowerDefaultPerformance();
+GR_RESULT GR_STDCALL grSetPowerDefaultPerformance();
 
-GR_RESULT grSetPowerProfile();
+GR_RESULT GR_STDCALL grSetPowerProfile();
 
-GR_RESULT grSetPowerRegions();
+GR_RESULT GR_STDCALL grSetPowerRegions();
 
-GR_RESULT grSetPrivateDisplayPowerMode();
+GR_RESULT GR_STDCALL grSetPrivateDisplayPowerMode();
 
-GR_RESULT grSetPrivateDisplaySettings();
+GR_RESULT GR_STDCALL grSetPrivateDisplaySettings();
 
-GR_RESULT grWinAllocMemory();
+GR_RESULT GR_STDCALL grWinAllocMemory();
 
-GR_RESULT grWinOpenExternalSharedImage();
+GR_RESULT GR_STDCALL grWinOpenExternalSharedImage();
 
-GR_RESULT grWinOpenExternalSharedMemory();
+GR_RESULT GR_STDCALL grWinOpenExternalSharedMemory();
 
-GR_RESULT grWinOpenExternalSharedQueueSemaphore();
+GR_RESULT GR_STDCALL grWinOpenExternalSharedQueueSemaphore();
 
 #ifdef __cplusplus
 }

--- a/include/mantle/mantleWsiWinExt.h
+++ b/include/mantle/mantleWsiWinExt.h
@@ -163,45 +163,45 @@ typedef struct _GR_WSI_WIN_QUEUE_PROPERTIES
 
 // Functions
 
-GR_RESULT grWsiWinGetDisplays(
+GR_RESULT GR_STDCALL grWsiWinGetDisplays(
     GR_DEVICE device,
     GR_UINT* pDisplayCount,
     GR_WSI_WIN_DISPLAY* pDisplayList);
 
-GR_RESULT grWsiWinGetDisplayModeList(
+GR_RESULT GR_STDCALL grWsiWinGetDisplayModeList(
     GR_WSI_WIN_DISPLAY display,
     GR_UINT* pDisplayModeCount,
     GR_WSI_WIN_DISPLAY_MODE* pDisplayModeList);
 
-GR_RESULT grWsiWinTakeFullscreenOwnership(
+GR_RESULT GR_STDCALL grWsiWinTakeFullscreenOwnership(
     GR_WSI_WIN_DISPLAY display,
     GR_IMAGE image);
 
-GR_RESULT grWsiWinReleaseFullscreenOwnership(
+GR_RESULT GR_STDCALL grWsiWinReleaseFullscreenOwnership(
     GR_WSI_WIN_DISPLAY display);
 
-GR_RESULT grWsiWinSetGammaRamp(
+GR_RESULT GR_STDCALL grWsiWinSetGammaRamp(
     GR_WSI_WIN_DISPLAY display,
     const GR_WSI_WIN_GAMMA_RAMP* pGammaRamp);
 
-GR_RESULT grWsiWinWaitForVerticalBlank(
+GR_RESULT GR_STDCALL grWsiWinWaitForVerticalBlank(
     GR_WSI_WIN_DISPLAY display);
 
-GR_RESULT grWsiWinGetScanLine(
+GR_RESULT GR_STDCALL grWsiWinGetScanLine(
     GR_WSI_WIN_DISPLAY display,
     GR_INT* pScanLine);
 
-GR_RESULT grWsiWinCreatePresentableImage(
+GR_RESULT GR_STDCALL grWsiWinCreatePresentableImage(
     GR_DEVICE device,
     const GR_WSI_WIN_PRESENTABLE_IMAGE_CREATE_INFO* pCreateInfo,
     GR_IMAGE* pImage,
     GR_GPU_MEMORY* pMem);
 
-GR_RESULT grWsiWinQueuePresent(
+GR_RESULT GR_STDCALL grWsiWinQueuePresent(
     GR_QUEUE queue,
     const GR_WSI_WIN_PRESENT_INFO* pPresentInfo);
 
-GR_RESULT grWsiWinSetMaxQueuedFrames(
+GR_RESULT GR_STDCALL grWsiWinSetMaxQueuedFrames(
     GR_DEVICE device,
     GR_UINT maxFrames);
 

--- a/src/mantle/mantle_cmd_buf_man.c
+++ b/src/mantle/mantle_cmd_buf_man.c
@@ -26,7 +26,7 @@ void grCmdBufferResetState(
 
 // Command Buffer Management Functions
 
-GR_RESULT grCreateCommandBuffer(
+GR_RESULT GR_STDCALL grCreateCommandBuffer(
     GR_DEVICE device,
     const GR_CMD_BUFFER_CREATE_INFO* pCreateInfo,
     GR_CMD_BUFFER* pCmdBuffer)
@@ -104,7 +104,7 @@ GR_RESULT grCreateCommandBuffer(
     return GR_SUCCESS;
 }
 
-GR_RESULT grBeginCommandBuffer(
+GR_RESULT GR_STDCALL grBeginCommandBuffer(
     GR_CMD_BUFFER cmdBuffer,
     GR_FLAGS flags)
 {
@@ -148,7 +148,7 @@ GR_RESULT grBeginCommandBuffer(
     return GR_SUCCESS;
 }
 
-GR_RESULT grEndCommandBuffer(
+GR_RESULT GR_STDCALL grEndCommandBuffer(
     GR_CMD_BUFFER cmdBuffer)
 {
     LOGT("%p\n", cmdBuffer);
@@ -177,7 +177,7 @@ GR_RESULT grEndCommandBuffer(
     return GR_SUCCESS;
 }
 
-GR_RESULT grResetCommandBuffer(
+GR_RESULT GR_STDCALL grResetCommandBuffer(
     GR_CMD_BUFFER cmdBuffer)
 {
     LOGT("%p\n", cmdBuffer);

--- a/src/mantle/mantle_descriptor_set.c
+++ b/src/mantle/mantle_descriptor_set.c
@@ -2,7 +2,7 @@
 
 // Descriptor Set Functions
 
-GR_RESULT grCreateDescriptorSet(
+GR_RESULT GR_STDCALL grCreateDescriptorSet(
     GR_DEVICE device,
     const GR_DESCRIPTOR_SET_CREATE_INFO* pCreateInfo,
     GR_DESCRIPTOR_SET* pDescriptorSet)

--- a/src/mantle/mantle_extension_discovery.c
+++ b/src/mantle/mantle_extension_discovery.c
@@ -2,7 +2,7 @@
 
 // Extension Discovery Functions
 
-GR_RESULT grGetExtensionSupport(
+GR_RESULT GR_STDCALL grGetExtensionSupport(
     GR_PHYSICAL_GPU gpu,
     const GR_CHAR* pExtName)
 {

--- a/src/mantle/mantle_image_sample.c
+++ b/src/mantle/mantle_image_sample.c
@@ -74,7 +74,7 @@ unsigned grImageGetBufferDepthPitch(
 
 // Image and Sample Functions
 
-GR_RESULT grGetFormatInfo(
+GR_RESULT GR_STDCALL grGetFormatInfo(
     GR_DEVICE device,
     GR_FORMAT format,
     GR_ENUM infoType,
@@ -121,7 +121,7 @@ GR_RESULT grGetFormatInfo(
     return GR_SUCCESS;
 }
 
-GR_RESULT grCreateImage(
+GR_RESULT GR_STDCALL grCreateImage(
     GR_DEVICE device,
     const GR_IMAGE_CREATE_INFO* pCreateInfo,
     GR_IMAGE* pImage)
@@ -292,7 +292,7 @@ GR_RESULT grCreateImage(
     return GR_SUCCESS;
 }
 
-GR_RESULT grGetImageSubresourceInfo(
+GR_RESULT GR_STDCALL grGetImageSubresourceInfo(
     GR_IMAGE image,
     const GR_IMAGE_SUBRESOURCE* pSubresource,
     GR_ENUM infoType,
@@ -363,7 +363,7 @@ GR_RESULT grGetImageSubresourceInfo(
     return GR_SUCCESS;
 }
 
-GR_RESULT grCreateSampler(
+GR_RESULT GR_STDCALL grCreateSampler(
     GR_DEVICE device,
     const GR_SAMPLER_CREATE_INFO* pCreateInfo,
     GR_SAMPLER* pSampler)

--- a/src/mantle/mantle_image_view.c
+++ b/src/mantle/mantle_image_view.c
@@ -2,7 +2,7 @@
 
 // Image View Functions
 
-GR_RESULT grCreateImageView(
+GR_RESULT GR_STDCALL grCreateImageView(
     GR_DEVICE device,
     const GR_IMAGE_VIEW_CREATE_INFO* pCreateInfo,
     GR_IMAGE_VIEW* pView)
@@ -107,7 +107,7 @@ GR_RESULT grCreateImageView(
     return GR_SUCCESS;
 }
 
-GR_RESULT grCreateColorTargetView(
+GR_RESULT GR_STDCALL grCreateColorTargetView(
     GR_DEVICE device,
     const GR_COLOR_TARGET_VIEW_CREATE_INFO* pCreateInfo,
     GR_COLOR_TARGET_VIEW* pView)
@@ -178,7 +178,7 @@ GR_RESULT grCreateColorTargetView(
     return GR_SUCCESS;
 }
 
-GR_RESULT grCreateDepthStencilView(
+GR_RESULT GR_STDCALL grCreateDepthStencilView(
     GR_DEVICE device,
     const GR_DEPTH_STENCIL_VIEW_CREATE_INFO* pCreateInfo,
     GR_DEPTH_STENCIL_VIEW* pView)

--- a/src/mantle/mantle_init_device.c
+++ b/src/mantle/mantle_init_device.c
@@ -21,7 +21,7 @@ static char* getGrvkEngineName(
 
 // Initialization and Device Functions
 
-GR_RESULT grInitAndEnumerateGpus(
+GR_RESULT GR_STDCALL grInitAndEnumerateGpus(
     const GR_APPLICATION_INFO* pAppInfo,
     const GR_ALLOC_CALLBACKS* pAllocCb,
     GR_UINT* pGpuCount,
@@ -113,7 +113,7 @@ GR_RESULT grInitAndEnumerateGpus(
     return GR_SUCCESS;
 }
 
-GR_RESULT grGetGpuInfo(
+GR_RESULT GR_STDCALL grGetGpuInfo(
     GR_PHYSICAL_GPU gpu,
     GR_ENUM infoType,
     GR_SIZE* pDataSize,
@@ -290,7 +290,7 @@ GR_RESULT grGetGpuInfo(
     return GR_SUCCESS;
 }
 
-GR_RESULT grCreateDevice(
+GR_RESULT GR_STDCALL grCreateDevice(
     GR_PHYSICAL_GPU gpu,
     const GR_DEVICE_CREATE_INFO* pCreateInfo,
     GR_DEVICE* pDevice)
@@ -485,7 +485,7 @@ bail:
     return res;
 }
 
-GR_RESULT grDestroyDevice(
+GR_RESULT GR_STDCALL grDestroyDevice(
     GR_DEVICE device)
 {
     LOGT("%p\n", device);

--- a/src/mantle/mantle_memory_man.c
+++ b/src/mantle/mantle_memory_man.c
@@ -47,7 +47,7 @@ void grGpuMemoryBindBuffer(
 
 // Memory Management Functions
 
-GR_RESULT grGetMemoryHeapCount(
+GR_RESULT GR_STDCALL grGetMemoryHeapCount(
     GR_DEVICE device,
     GR_UINT* pCount)
 {
@@ -66,7 +66,7 @@ GR_RESULT grGetMemoryHeapCount(
     return GR_SUCCESS;
 }
 
-GR_RESULT grGetMemoryHeapInfo(
+GR_RESULT GR_STDCALL grGetMemoryHeapInfo(
     GR_DEVICE device,
     GR_UINT heapId,
     GR_ENUM infoType,
@@ -133,7 +133,7 @@ GR_RESULT grGetMemoryHeapInfo(
     return GR_SUCCESS;
 }
 
-GR_RESULT grAllocMemory(
+GR_RESULT GR_STDCALL grAllocMemory(
     GR_DEVICE device,
     const GR_MEMORY_ALLOC_INFO* pAllocInfo,
     GR_GPU_MEMORY* pMem)
@@ -199,12 +199,11 @@ GR_RESULT grAllocMemory(
     };
 
     InitializeCriticalSectionAndSpinCount(&grGpuMemory->boundObjectsMutex, 0);
-
     *pMem = (GR_GPU_MEMORY)grGpuMemory;
     return GR_SUCCESS;
 }
 
-GR_RESULT grFreeMemory(
+GR_RESULT GR_STDCALL grFreeMemory(
     GR_GPU_MEMORY mem)
 {
     LOGT("%p\n", mem);
@@ -225,7 +224,7 @@ GR_RESULT grFreeMemory(
     return GR_SUCCESS;
 }
 
-GR_RESULT grMapMemory(
+GR_RESULT GR_STDCALL grMapMemory(
     GR_GPU_MEMORY mem,
     GR_FLAGS flags,
     GR_VOID** ppData)
@@ -254,7 +253,7 @@ GR_RESULT grMapMemory(
     return getGrResult(vkRes);
 }
 
-GR_RESULT grUnmapMemory(
+GR_RESULT GR_STDCALL grUnmapMemory(
     GR_GPU_MEMORY mem)
 {
     LOGT("%p\n", mem);

--- a/src/mantle/mantle_multi_dev_man.c
+++ b/src/mantle/mantle_multi_dev_man.c
@@ -2,7 +2,7 @@
 
 // Multi-Device Management Functions
 
-GR_RESULT grGetMultiGpuCompatibility(
+GR_RESULT GR_STDCALL grGetMultiGpuCompatibility(
     GR_PHYSICAL_GPU gpu0,
     GR_PHYSICAL_GPU gpu1,
     GR_GPU_COMPATIBILITY_INFO* pInfo)

--- a/src/mantle/mantle_object_man.c
+++ b/src/mantle/mantle_object_man.c
@@ -2,7 +2,7 @@
 
 // Generic API Object Management functions
 
-GR_RESULT grDestroyObject(
+GR_RESULT GR_STDCALL grDestroyObject(
     GR_OBJECT object)
 {
     LOGT("%p\n", object);
@@ -48,7 +48,7 @@ GR_RESULT grDestroyObject(
     return GR_SUCCESS;
 }
 
-GR_RESULT grGetObjectInfo(
+GR_RESULT GR_STDCALL grGetObjectInfo(
     GR_BASE_OBJECT object,
     GR_ENUM infoType,
     GR_SIZE* pDataSize,
@@ -172,7 +172,7 @@ GR_RESULT grGetObjectInfo(
     return GR_SUCCESS;
 }
 
-GR_RESULT grBindObjectMemory(
+GR_RESULT GR_STDCALL grBindObjectMemory(
     GR_OBJECT object,
     GR_GPU_MEMORY mem,
     GR_GPU_SIZE offset)

--- a/src/mantle/mantle_query_sync.c
+++ b/src/mantle/mantle_query_sync.c
@@ -2,7 +2,7 @@
 
 // Query and Synchronization Functions
 
-GR_RESULT grCreateQueryPool(
+GR_RESULT GR_STDCALL grCreateQueryPool(
     GR_DEVICE device,
     const GR_QUERY_POOL_CREATE_INFO* pCreateInfo,
     GR_QUERY_POOL* pQueryPool)
@@ -59,7 +59,7 @@ GR_RESULT grCreateQueryPool(
     return GR_SUCCESS;
 }
 
-GR_RESULT grCreateFence(
+GR_RESULT GR_STDCALL grCreateFence(
     GR_DEVICE device,
     const GR_FENCE_CREATE_INFO* pCreateInfo,
     GR_FENCE* pFence)
@@ -95,7 +95,7 @@ GR_RESULT grCreateFence(
     return GR_SUCCESS;
 }
 
-GR_RESULT grGetFenceStatus(
+GR_RESULT GR_STDCALL grGetFenceStatus(
     GR_FENCE fence)
 {
     LOGT("%p\n", fence);
@@ -121,7 +121,7 @@ GR_RESULT grGetFenceStatus(
     return getGrResult(res);
 }
 
-GR_RESULT grWaitForFences(
+GR_RESULT GR_STDCALL grWaitForFences(
     GR_DEVICE device,
     GR_UINT fenceCount,
     const GR_FENCE* pFences,
@@ -167,7 +167,7 @@ GR_RESULT grWaitForFences(
     return getGrResult(res);
 }
 
-GR_RESULT grCreateQueueSemaphore(
+GR_RESULT GR_STDCALL grCreateQueueSemaphore(
     GR_DEVICE device,
     const GR_QUEUE_SEMAPHORE_CREATE_INFO* pCreateInfo,
     GR_QUEUE_SEMAPHORE* pSemaphore)
@@ -215,7 +215,7 @@ GR_RESULT grCreateQueueSemaphore(
     return GR_SUCCESS;
 }
 
-GR_RESULT grSignalQueueSemaphore(
+GR_RESULT GR_STDCALL grSignalQueueSemaphore(
     GR_QUEUE queue,
     GR_QUEUE_SEMAPHORE semaphore)
 {
@@ -251,7 +251,7 @@ GR_RESULT grSignalQueueSemaphore(
     return getGrResult(res);
 }
 
-GR_RESULT grWaitQueueSemaphore(
+GR_RESULT GR_STDCALL grWaitQueueSemaphore(
     GR_QUEUE queue,
     GR_QUEUE_SEMAPHORE semaphore)
 {
@@ -288,7 +288,7 @@ GR_RESULT grWaitQueueSemaphore(
     return getGrResult(res);
 }
 
-GR_RESULT grCreateEvent(
+GR_RESULT GR_STDCALL grCreateEvent(
     GR_DEVICE device,
     const GR_EVENT_CREATE_INFO* pCreateInfo,
     GR_EVENT* pEvent)
@@ -328,7 +328,7 @@ GR_RESULT grCreateEvent(
     return GR_SUCCESS;
 }
 
-GR_RESULT grGetEventStatus(
+GR_RESULT GR_STDCALL grGetEventStatus(
     GR_EVENT event)
 {
     LOGT("%p\n", event);
@@ -350,7 +350,7 @@ GR_RESULT grGetEventStatus(
     return getGrResult(res);
 }
 
-GR_RESULT grSetEvent(
+GR_RESULT GR_STDCALL grSetEvent(
     GR_EVENT event)
 {
     LOGT("%p\n", event);
@@ -372,7 +372,7 @@ GR_RESULT grSetEvent(
     return getGrResult(res);
 }
 
-GR_RESULT grResetEvent(
+GR_RESULT GR_STDCALL grResetEvent(
     GR_EVENT event)
 {
     LOGT("%p\n", event);

--- a/src/mantle/mantle_queue.c
+++ b/src/mantle/mantle_queue.c
@@ -104,7 +104,7 @@ static void checkMemoryReferences(
 
 // Queue Functions
 
-GR_RESULT grGetDeviceQueue(
+GR_RESULT GR_STDCALL grGetDeviceQueue(
     GR_DEVICE device,
     GR_ENUM queueType,
     GR_UINT queueId,
@@ -142,7 +142,7 @@ GR_RESULT grGetDeviceQueue(
     return GR_SUCCESS;
 }
 
-GR_RESULT grQueueSubmit(
+GR_RESULT GR_STDCALL grQueueSubmit(
     GR_QUEUE queue,
     GR_UINT cmdBufferCount,
     const GR_CMD_BUFFER* pCmdBuffers,
@@ -207,7 +207,7 @@ GR_RESULT grQueueSubmit(
     return getGrResult(res);
 }
 
-GR_RESULT grQueueWaitIdle(
+GR_RESULT GR_STDCALL grQueueWaitIdle(
     GR_QUEUE queue)
 {
     LOGT("%p\n", queue);
@@ -228,7 +228,7 @@ GR_RESULT grQueueWaitIdle(
     return getGrResult(res);
 }
 
-GR_RESULT grDeviceWaitIdle(
+GR_RESULT GR_STDCALL grDeviceWaitIdle(
     GR_DEVICE device)
 {
     LOGT("%p\n", device);
@@ -248,7 +248,7 @@ GR_RESULT grDeviceWaitIdle(
     return getGrResult(res);
 }
 
-GR_RESULT grQueueSetGlobalMemReferences(
+GR_RESULT GR_STDCALL grQueueSetGlobalMemReferences(
     GR_QUEUE queue,
     GR_UINT memRefCount,
     const GR_MEMORY_REF* pMemRefs)

--- a/src/mantle/mantle_shader_pipeline.c
+++ b/src/mantle/mantle_shader_pipeline.c
@@ -487,7 +487,7 @@ VkPipeline grPipelineFindOrCreateVkPipeline(
 
 // Shader and Pipeline Functions
 
-GR_RESULT grCreateShader(
+GR_RESULT GR_STDCALL grCreateShader(
     GR_DEVICE device,
     const GR_SHADER_CREATE_INFO* pCreateInfo,
     GR_SHADER* pShader)
@@ -531,7 +531,7 @@ GR_RESULT grCreateShader(
     return GR_SUCCESS;
 }
 
-GR_RESULT grCreateGraphicsPipeline(
+GR_RESULT GR_STDCALL grCreateGraphicsPipeline(
     GR_DEVICE device,
     const GR_GRAPHICS_PIPELINE_CREATE_INFO* pCreateInfo,
     GR_PIPELINE* pPipeline)
@@ -686,7 +686,7 @@ bail:
     return res;
 }
 
-GR_RESULT grCreateComputePipeline(
+GR_RESULT GR_STDCALL grCreateComputePipeline(
     GR_DEVICE device,
     const GR_COMPUTE_PIPELINE_CREATE_INFO* pCreateInfo,
     GR_PIPELINE* pPipeline)

--- a/src/mantle/mantle_state_object.c
+++ b/src/mantle/mantle_state_object.c
@@ -2,7 +2,7 @@
 
 // State Object Functions
 
-GR_RESULT grCreateViewportState(
+GR_RESULT GR_STDCALL grCreateViewportState(
     GR_DEVICE device,
     const GR_VIEWPORT_STATE_CREATE_INFO* pCreateInfo,
     GR_VIEWPORT_STATE_OBJECT* pState)
@@ -91,7 +91,7 @@ GR_RESULT grCreateViewportState(
     return GR_SUCCESS;
 }
 
-GR_RESULT grCreateRasterState(
+GR_RESULT GR_STDCALL grCreateRasterState(
     GR_DEVICE device,
     const GR_RASTER_STATE_CREATE_INFO* pCreateInfo,
     GR_RASTER_STATE_OBJECT* pState)
@@ -117,7 +117,7 @@ GR_RESULT grCreateRasterState(
     return GR_SUCCESS;
 }
 
-GR_RESULT grCreateColorBlendState(
+GR_RESULT GR_STDCALL grCreateColorBlendState(
     GR_DEVICE device,
     const GR_COLOR_BLEND_STATE_CREATE_INFO* pCreateInfo,
     GR_COLOR_BLEND_STATE_OBJECT* pState)
@@ -171,7 +171,7 @@ GR_RESULT grCreateColorBlendState(
     return GR_SUCCESS;
 }
 
-GR_RESULT grCreateDepthStencilState(
+GR_RESULT GR_STDCALL grCreateDepthStencilState(
     GR_DEVICE device,
     const GR_DEPTH_STENCIL_STATE_CREATE_INFO* pCreateInfo,
     GR_DEPTH_STENCIL_STATE_OBJECT* pState)
@@ -217,7 +217,7 @@ GR_RESULT grCreateDepthStencilState(
     return GR_SUCCESS;
 }
 
-GR_RESULT grCreateMsaaState(
+GR_RESULT GR_STDCALL grCreateMsaaState(
     GR_DEVICE device,
     const GR_MSAA_STATE_CREATE_INFO* pCreateInfo,
     GR_MSAA_STATE_OBJECT* pState)

--- a/src/mantle/mantle_wsi.c
+++ b/src/mantle/mantle_wsi.c
@@ -256,7 +256,7 @@ static void initSwapchain(
 
 // Functions
 
-GR_RESULT grWsiWinGetDisplays(
+GR_RESULT GR_STDCALL grWsiWinGetDisplays(
     GR_DEVICE device,
     GR_UINT* pDisplayCount,
     GR_WSI_WIN_DISPLAY* pDisplayList)
@@ -298,7 +298,7 @@ GR_RESULT grWsiWinGetDisplays(
     return GR_SUCCESS;
 }
 
-GR_RESULT grWsiWinGetDisplayModeList(
+GR_RESULT GR_STDCALL grWsiWinGetDisplayModeList(
     GR_WSI_WIN_DISPLAY display,
     GR_UINT* pDisplayModeCount,
     GR_WSI_WIN_DISPLAY_MODE* pDisplayModeList)
@@ -339,7 +339,7 @@ GR_RESULT grWsiWinGetDisplayModeList(
     return GR_SUCCESS;
 }
 
-GR_RESULT grWsiWinTakeFullscreenOwnership(
+GR_RESULT GR_STDCALL grWsiWinTakeFullscreenOwnership(
     GR_WSI_WIN_DISPLAY display,
     GR_IMAGE image)
 {
@@ -356,7 +356,7 @@ GR_RESULT grWsiWinTakeFullscreenOwnership(
     return GR_SUCCESS;
 }
 
-GR_RESULT grWsiWinCreatePresentableImage(
+GR_RESULT GR_STDCALL grWsiWinCreatePresentableImage(
     GR_DEVICE device,
     const GR_WSI_WIN_PRESENTABLE_IMAGE_CREATE_INFO* pCreateInfo,
     GR_IMAGE* pImage,
@@ -427,7 +427,7 @@ GR_RESULT grWsiWinCreatePresentableImage(
     return GR_SUCCESS;
 }
 
-GR_RESULT grWsiWinQueuePresent(
+GR_RESULT GR_STDCALL grWsiWinQueuePresent(
     GR_QUEUE queue,
     const GR_WSI_WIN_PRESENT_INFO* pPresentInfo)
 {
@@ -503,7 +503,7 @@ GR_RESULT grWsiWinQueuePresent(
     return GR_SUCCESS;
 }
 
-GR_RESULT grWsiWinSetMaxQueuedFrames(
+GR_RESULT GR_STDCALL grWsiWinSetMaxQueuedFrames(
     GR_DEVICE device,
     GR_UINT maxFrames)
 {

--- a/src/mantle/stub.c
+++ b/src/mantle/stub.c
@@ -6,7 +6,7 @@
 
 // Memory Management Functions
 
-GR_RESULT grSetMemoryPriority(
+GR_RESULT GR_STDCALL grSetMemoryPriority(
     GR_GPU_MEMORY mem,
     GR_ENUM priority)
 {
@@ -14,7 +14,7 @@ GR_RESULT grSetMemoryPriority(
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grRemapVirtualMemoryPages(
+GR_RESULT GR_STDCALL grRemapVirtualMemoryPages(
     GR_DEVICE device,
     GR_UINT rangeCount,
     const GR_VIRTUAL_MEMORY_REMAP_RANGE* pRanges,
@@ -27,7 +27,7 @@ GR_RESULT grRemapVirtualMemoryPages(
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grPinSystemMemory(
+GR_RESULT GR_STDCALL grPinSystemMemory(
     GR_DEVICE device,
     const GR_VOID* pSysMem,
     GR_SIZE memSize,
@@ -39,7 +39,7 @@ GR_RESULT grPinSystemMemory(
 
 // Shader and Pipeline Functions
 
-GR_RESULT grStorePipeline(
+GR_RESULT GR_STDCALL grStorePipeline(
     GR_PIPELINE pipeline,
     GR_SIZE* pDataSize,
     GR_VOID* pData)
@@ -48,7 +48,7 @@ GR_RESULT grStorePipeline(
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grLoadPipeline(
+GR_RESULT GR_STDCALL grLoadPipeline(
     GR_DEVICE device,
     GR_SIZE dataSize,
     const GR_VOID* pData,
@@ -60,7 +60,7 @@ GR_RESULT grLoadPipeline(
 
 // Query and Synchronization Functions
 
-GR_RESULT grGetQueryPoolResults(
+GR_RESULT GR_STDCALL grGetQueryPoolResults(
     GR_QUERY_POOL queryPool,
     GR_UINT startQuery,
     GR_UINT queryCount,
@@ -73,7 +73,7 @@ GR_RESULT grGetQueryPoolResults(
 
 // Multi-Device Management Functions
 
-GR_RESULT grOpenSharedMemory(
+GR_RESULT GR_STDCALL grOpenSharedMemory(
     GR_DEVICE device,
     const GR_MEMORY_OPEN_INFO* pOpenInfo,
     GR_GPU_MEMORY* pMem)
@@ -82,7 +82,7 @@ GR_RESULT grOpenSharedMemory(
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grOpenSharedQueueSemaphore(
+GR_RESULT GR_STDCALL grOpenSharedQueueSemaphore(
     GR_DEVICE device,
     const GR_QUEUE_SEMAPHORE_OPEN_INFO* pOpenInfo,
     GR_QUEUE_SEMAPHORE* pSemaphore)
@@ -91,7 +91,7 @@ GR_RESULT grOpenSharedQueueSemaphore(
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grOpenPeerMemory(
+GR_RESULT GR_STDCALL grOpenPeerMemory(
     GR_DEVICE device,
     const GR_PEER_MEMORY_OPEN_INFO* pOpenInfo,
     GR_GPU_MEMORY* pMem)
@@ -100,7 +100,7 @@ GR_RESULT grOpenPeerMemory(
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grOpenPeerImage(
+GR_RESULT GR_STDCALL grOpenPeerImage(
     GR_DEVICE device,
     const GR_PEER_IMAGE_OPEN_INFO* pOpenInfo,
     GR_IMAGE* pImage,
@@ -237,7 +237,7 @@ GR_RESULT GR_STDCALL grDbgSetValidationLevel(
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grDbgRegisterMsgCallback(
+GR_RESULT GR_STDCALL grDbgRegisterMsgCallback(
     GR_DBG_MSG_CALLBACK_FUNCTION pfnMsgCallback,
     GR_VOID* pUserData)
 {
@@ -245,14 +245,14 @@ GR_RESULT grDbgRegisterMsgCallback(
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grDbgUnregisterMsgCallback(
+GR_RESULT GR_STDCALL grDbgUnregisterMsgCallback(
     GR_DBG_MSG_CALLBACK_FUNCTION pfnMsgCallback)
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grDbgSetMessageFilter(
+GR_RESULT GR_STDCALL grDbgSetMessageFilter(
     GR_DEVICE device,
     GR_ENUM msgCode,
     GR_ENUM filter)
@@ -261,7 +261,7 @@ GR_RESULT grDbgSetMessageFilter(
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grDbgSetObjectTag(
+GR_RESULT GR_STDCALL grDbgSetObjectTag(
     GR_BASE_OBJECT object,
     GR_SIZE tagSize,
     const GR_VOID* pTag)
@@ -270,7 +270,7 @@ GR_RESULT grDbgSetObjectTag(
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grDbgSetGlobalOption(
+GR_RESULT GR_STDCALL grDbgSetGlobalOption(
     GR_DBG_GLOBAL_OPTION dbgOption,
     GR_SIZE dataSize,
     const GR_VOID* pData)
@@ -279,7 +279,7 @@ GR_RESULT grDbgSetGlobalOption(
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grDbgSetDeviceOption(
+GR_RESULT GR_STDCALL grDbgSetDeviceOption(
     GR_DEVICE device,
     GR_DBG_DEVICE_OPTION dbgOption,
     GR_SIZE dataSize,
@@ -304,14 +304,14 @@ GR_VOID GR_STDCALL grCmdDbgMarkerEnd(
 
 // WSI Functions
 
-GR_RESULT grWsiWinReleaseFullscreenOwnership(
+GR_RESULT GR_STDCALL grWsiWinReleaseFullscreenOwnership(
     GR_WSI_WIN_DISPLAY display)
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grWsiWinSetGammaRamp(
+GR_RESULT GR_STDCALL grWsiWinSetGammaRamp(
     GR_WSI_WIN_DISPLAY display,
     const GR_WSI_WIN_GAMMA_RAMP* pGammaRamp)
 {
@@ -319,14 +319,14 @@ GR_RESULT grWsiWinSetGammaRamp(
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grWsiWinWaitForVerticalBlank(
+GR_RESULT GR_STDCALL grWsiWinWaitForVerticalBlank(
     GR_WSI_WIN_DISPLAY display)
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grWsiWinGetScanLine(
+GR_RESULT GR_STDCALL grWsiWinGetScanLine(
     GR_WSI_WIN_DISPLAY display,
     GR_INT* pScanLine)
 {

--- a/src/mantleaxl/mantleaxl_border_color_palette_ext.c
+++ b/src/mantleaxl/mantleaxl_border_color_palette_ext.c
@@ -4,7 +4,7 @@
 
 // Border Color Palette Extension Functions
 
-GR_RESULT grCreateBorderColorPalette(
+GR_RESULT GR_STDCALL grCreateBorderColorPalette(
     GR_DEVICE device,
     const GR_BORDER_COLOR_PALETTE_CREATE_INFO* pCreateInfo,
     GR_BORDER_COLOR_PALETTE* pPalette)
@@ -33,7 +33,7 @@ GR_RESULT grCreateBorderColorPalette(
     return GR_SUCCESS;
 }
 
-GR_RESULT grUpdateBorderColorPalette(
+GR_RESULT GR_STDCALL grUpdateBorderColorPalette(
     GR_BORDER_COLOR_PALETTE palette,
     GR_UINT firstEntry,
     GR_UINT entryCount,

--- a/src/mantleaxl/stub.c
+++ b/src/mantleaxl/stub.c
@@ -13,7 +13,7 @@ GR_VOID grCmdBindBorderColorPalette(
 
 // Advanced Multisampling Extnension Functions
 
-GR_RESULT grCreateAdvancedMsaaState(
+GR_RESULT GR_STDCALL grCreateAdvancedMsaaState(
     GR_DEVICE device,
     const GR_ADVANCED_MSAA_STATE_CREATE_INFO* pCreateInfo,
     GR_MSAA_STATE_OBJECT* pState)
@@ -22,7 +22,7 @@ GR_RESULT grCreateAdvancedMsaaState(
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grCreateFmaskImageView(
+GR_RESULT GR_STDCALL grCreateFmaskImageView(
     GR_DEVICE device,
     const GR_FMASK_IMAGE_VIEW_CREATE_INFO* pCreateInfo,
     GR_IMAGE_VIEW* pView)
@@ -33,7 +33,7 @@ GR_RESULT grCreateFmaskImageView(
 
 // Copy Occlusion Query Data Extension Functions
 
-GR_RESULT grCmdCopyOcclusionData(
+GR_RESULT GR_STDCALL grCmdCopyOcclusionData(
     GR_CMD_BUFFER cmdBuffer,
     GR_QUERY_POOL queryPool,
     GR_UINT startQuery,
@@ -121,7 +121,7 @@ GR_VOID grCmdEndWhile(
 
 // Timer Queue Extension Functions
 
-GR_RESULT grQueueDelay(
+GR_RESULT GR_STDCALL grQueueDelay(
     GR_QUEUE queue,
     GR_FLOAT delay)
 {
@@ -129,7 +129,7 @@ GR_RESULT grQueueDelay(
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grCalibrateGpuTimestamp(
+GR_RESULT GR_STDCALL grCalibrateGpuTimestamp(
     GR_DEVICE device,
     GR_GPU_TIMESTAMP_CALIBRATION* pCalibrationData)
 {
@@ -139,253 +139,253 @@ GR_RESULT grCalibrateGpuTimestamp(
 
 // Undocumented Functions
 
-GR_RESULT grAddEmulatedPrivateDisplay()
+GR_RESULT GR_STDCALL grAddEmulatedPrivateDisplay()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grAddPerfExperimentCounter()
+GR_RESULT GR_STDCALL grAddPerfExperimentCounter()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grAddPerfExperimentTrace()
+GR_RESULT GR_STDCALL grAddPerfExperimentTrace()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grBlankPrivateDisplay()
+GR_RESULT GR_STDCALL grBlankPrivateDisplay()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grCmdBeginPerfExperiment()
+GR_RESULT GR_STDCALL grCmdBeginPerfExperiment()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grCmdBindUserData()
+GR_RESULT GR_STDCALL grCmdBindUserData()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grCmdCopyRegisterToMemory()
+GR_RESULT GR_STDCALL grCmdCopyRegisterToMemory()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grCmdDispatchOffset()
+GR_RESULT GR_STDCALL grCmdDispatchOffset()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grCmdDispatchOffsetIndirect()
+GR_RESULT GR_STDCALL grCmdDispatchOffsetIndirect()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grCmdEndPerfExperiment()
+GR_RESULT GR_STDCALL grCmdEndPerfExperiment()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grCmdInsertTraceMarker()
+GR_RESULT GR_STDCALL grCmdInsertTraceMarker()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grCmdWaitMemoryValue()
+GR_RESULT GR_STDCALL grCmdWaitMemoryValue()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grCmdWaitRegisterValue()
+GR_RESULT GR_STDCALL grCmdWaitRegisterValue()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grCreatePerfExperiment()
+GR_RESULT GR_STDCALL grCreatePerfExperiment()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grCreatePrivateDisplayImage()
+GR_RESULT GR_STDCALL grCreatePrivateDisplayImage()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grCreateVirtualDisplay()
+GR_RESULT GR_STDCALL grCreateVirtualDisplay()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grDestroyVirtualDisplay()
+GR_RESULT GR_STDCALL grDestroyVirtualDisplay()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grDisablePrivateDisplay()
+GR_RESULT GR_STDCALL grDisablePrivateDisplay()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grEnablePrivateDisplay()
+GR_RESULT GR_STDCALL grEnablePrivateDisplay()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grEnablePrivateDisplayAudio()
+GR_RESULT GR_STDCALL grEnablePrivateDisplayAudio()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grFinalizePerfExperiment()
+GR_RESULT GR_STDCALL grFinalizePerfExperiment()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grGetPrivateDisplayScanLine()
+GR_RESULT GR_STDCALL grGetPrivateDisplayScanLine()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grGetPrivateDisplays()
+GR_RESULT GR_STDCALL grGetPrivateDisplays()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grGetVirtualDisplayProperties()
+GR_RESULT GR_STDCALL grGetVirtualDisplayProperties()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grOpenExternalSharedPrivateDisplayImage()
+GR_RESULT GR_STDCALL grOpenExternalSharedPrivateDisplayImage()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grPrivateDisplayPresent()
+GR_RESULT GR_STDCALL grPrivateDisplayPresent()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grQueueDelayAfterVsync()
+GR_RESULT GR_STDCALL grQueueDelayAfterVsync()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grQueueMigrateObjects()
+GR_RESULT GR_STDCALL grQueueMigrateObjects()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grQueueSetExecutionPriority()
+GR_RESULT GR_STDCALL grQueueSetExecutionPriority()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grRegisterPowerEvent()
+GR_RESULT GR_STDCALL grRegisterPowerEvent()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grRegisterPrivateDisplayEvent()
+GR_RESULT GR_STDCALL grRegisterPrivateDisplayEvent()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grRemoveEmulatedPrivateDisplay()
+GR_RESULT GR_STDCALL grRemoveEmulatedPrivateDisplay()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grSetEventAfterVsync()
+GR_RESULT GR_STDCALL grSetEventAfterVsync()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grSetPowerDefaultPerformance()
+GR_RESULT GR_STDCALL grSetPowerDefaultPerformance()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grSetPowerProfile()
+GR_RESULT GR_STDCALL grSetPowerProfile()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grSetPowerRegions()
+GR_RESULT GR_STDCALL grSetPowerRegions()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grSetPrivateDisplayPowerMode()
+GR_RESULT GR_STDCALL grSetPrivateDisplayPowerMode()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grSetPrivateDisplaySettings()
+GR_RESULT GR_STDCALL grSetPrivateDisplaySettings()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grWinAllocMemory()
+GR_RESULT GR_STDCALL grWinAllocMemory()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grWinOpenExternalSharedImage()
+GR_RESULT GR_STDCALL grWinOpenExternalSharedImage()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grWinOpenExternalSharedMemory()
+GR_RESULT GR_STDCALL grWinOpenExternalSharedMemory()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;
 }
 
-GR_RESULT grWinOpenExternalSharedQueueSemaphore()
+GR_RESULT GR_STDCALL grWinOpenExternalSharedQueueSemaphore()
 {
     LOGW("STUB\n");
     return GR_UNSUPPORTED;


### PR DESCRIPTION
Running 32-bit programs with mantle support tended to crash with some
catastrophic stack corruption. After some investigation, I realized the
problem was mismatched calling conventions. This patch defines
GR_STDCALL to __stdcall if _WIN32, otherwise it's defined as blank. This
lets CivBE successfully initialize (Per #16)