### PR TITLE
mantle: Ignore memory types with propertyFlags 0

### DIFF
--- a/src/mantle/mantle_memory_man.c
+++ b/src/mantle/mantle_memory_man.c
@@ -170,7 +170,7 @@ GR_RESULT GR_STDCALL grAllocMemory(
             .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
             .pNext = NULL,
             .allocationSize = pAllocInfo->size,
-            .memoryTypeIndex = pAllocInfo->heaps[i],
+            .memoryTypeIndex = grDevice->memoryProperties.memoryTypes[pAllocInfo->heaps[i]].typeIndex,
         };
 
         vkRes = VKD.vkAllocateMemory(grDevice->device, &allocateInfo, NULL, &vkMemory);

--- a/src/mantle/mantle_object.h
+++ b/src/mantle/mantle_object.h
@@ -204,12 +204,24 @@ typedef struct _GrDescriptorSet {
     DescriptorSetSlot* slots;
 } GrDescriptorSet;
 
+typedef struct _FilteredVkMemoryType {
+    uint32_t                 typeIndex;
+    VkMemoryPropertyFlags    propertyFlags;
+    uint32_t                 heapIndex;
+} FilteredVkMemoryType;
+typedef struct _FilteredVkPhysicalDeviceMemoryProperties {
+    uint32_t                memoryTypeCount;
+    FilteredVkMemoryType    memoryTypes[VK_MAX_MEMORY_TYPES];
+    uint32_t                memoryHeapCount;
+    VkMemoryHeap            memoryHeaps[VK_MAX_MEMORY_HEAPS];
+} FilteredVkPhysicalDeviceMemoryProperties;
+
 typedef struct _GrDevice {
     GrBaseObject grBaseObj;
     VULKAN_DEVICE vkd;
     VkDevice device;
     VkPhysicalDevice physicalDevice;
-    VkPhysicalDeviceMemoryProperties memoryProperties;
+    FilteredVkPhysicalDeviceMemoryProperties memoryProperties;
     unsigned universalQueueFamilyIndex;
     unsigned computeQueueFamilyIndex;
     unsigned dmaQueueFamilyIndex;

--- a/src/mantle/mantle_object_man.c
+++ b/src/mantle/mantle_object_man.c
@@ -133,6 +133,21 @@ GR_RESULT GR_STDCALL grGetObjectInfo(
                 VKD.vkGetBufferMemoryRequirements(grDevice->device, grImage->buffer, &memReqs);
             }
 
+            FilteredVkPhysicalDeviceMemoryProperties *memoryProps = &grDevice->memoryProperties;
+            int memoryTypeBits = 0;
+            for (int memoryType = 0; memoryType < VK_MAX_MEMORY_TYPES; memoryType++) {
+                if ((memReqs.memoryTypeBits & memoryType) == 0)
+                    continue;
+
+                for (int i = 0; i < memoryProps->memoryTypeCount; i++) {
+                    FilteredVkMemoryType *filteredMemoryType = &memoryProps->memoryTypes[i];
+                    if (filteredMemoryType->typeIndex == memoryType) {
+                        memoryTypeBits |= i;
+                    }
+                }
+            }
+            memReqs.memoryTypeBits = memoryTypeBits;
+
             *grMemReqs = getGrMemoryRequirements(memReqs);
         }   break;
         case GR_OBJ_TYPE_BORDER_COLOR_PALETTE:


### PR DESCRIPTION
I'm not that used to C, so there's probably a cleaner way to do this.

Also, I'd appreciate it, if you had any idea for a better name than `FilteredVkPhysicalDeviceMemoryProperties`. ._.