### PR TITLE
Handle atomic operations on UAV and LDS

### DIFF
--- a/src/amdilc/amdilc_compiler.c
+++ b/src/amdilc/amdilc_compiler.c
@@ -2802,9 +2802,31 @@ static void emitAppendBufOp(
         resource = addResource(compiler, &atomicCounterResource);
     }
 
-    SpvOp op = instr->opcode == IL_OP_APPEND_BUF_ALLOC ? SpvOpAtomicIIncrement
-                                                       : SpvOpAtomicIDecrement;
+    bool useSubgroupOps = compiler->kernel->shaderType == IL_SHADER_COMPUTE;
+    IlcSpvId electBlockBeginId;
+    IlcSpvId electBlockEndId;
+    IlcSpvId preElectBlockLabelId;
+    IlcSpvId workgroupScopeId;
+    IlcSpvId laneCountId, laneIndexId;
+    if (useSubgroupOps) {
+        preElectBlockLabelId = getTopBlockLabel(compiler);
+        electBlockBeginId = ilcSpvAllocId(compiler->module);
+        electBlockEndId = ilcSpvAllocId(compiler->module);
 
+        ilcSpvPutCapability(compiler->module, SpvCapabilityGroupNonUniform);
+        ilcSpvPutCapability(compiler->module, SpvCapabilityGroupNonUniformBallot);
+        workgroupScopeId = ilcSpvPutConstant(compiler->module, compiler->intId, SpvScopeWorkgroup);
+
+        IlcSpvId ballotId = ilcSpvPutGroupNonUniformBallot(compiler->module, compiler->uint4Id, workgroupScopeId, ilcSpvPutConstantTrue(compiler->module, compiler->boolId));
+        laneCountId = ilcSpvPutGroupNonUniformBallotBitCount(compiler->module, compiler->uintId, workgroupScopeId, SpvGroupOperationReduce, ballotId);
+        laneIndexId = ilcSpvPutGroupNonUniformBallotBitCount(compiler->module, compiler->uintId, workgroupScopeId, SpvGroupOperationExclusiveScan, ballotId);
+        IlcSpvId electionCondId = ilcSpvPutGroupNonUniformElect(compiler->module, compiler->boolId, workgroupScopeId);
+        ilcSpvPutSelectionMerge(compiler->module, electBlockEndId);
+        ilcSpvPutBranchConditional(compiler->module, electionCondId, electBlockBeginId, electBlockEndId);
+        ilcSpvPutLabel(compiler->module, electBlockBeginId);
+    } else {
+        laneCountId = ilcSpvPutConstant(compiler->module, compiler->uintId, 1u);
+    }
     IlcSpvId ptrTypeId = ilcSpvPutPointerType(compiler->module, SpvStorageClassStorageBuffer,
                                               compiler->uintId);
     IlcSpvId zeroId = ilcSpvPutConstant(compiler->module, compiler->intId, ZERO_LITERAL);
@@ -2816,10 +2838,27 @@ static void emitAppendBufOp(
     IlcSpvId semanticsId = ilcSpvPutConstant(compiler->module, compiler->intId,
                                              SpvMemorySemanticsAcquireReleaseMask |
                                              SpvMemorySemanticsUniformMemoryMask);
-    IlcSpvId readId = ilcSpvPutAtomicOp(compiler->module, op, compiler->uintId, ptrId,
-                                        scopeId, semanticsId, 0);
-    IlcSpvId resId = emitVectorGrow(compiler, readId, compiler->uintId, 1);
+    IlcSpvId readId;
+    SpvOp op = instr->opcode == IL_OP_APPEND_BUF_ALLOC ? SpvOpAtomicIAdd : SpvOpAtomicISub;
 
+    readId = ilcSpvPutAtomicOp(compiler->module, op, compiler->uintId, ptrId,
+                               scopeId, semanticsId, laneCountId);
+
+    if (useSubgroupOps) {
+        ilcSpvPutBranch(compiler->module, electBlockEndId);
+        ilcSpvPutLabel(compiler->module, electBlockEndId);
+
+        IlcSpvId constUndefId = ilcSpvPutConstantUndef(compiler->module, compiler->uintId);
+        IlcSpvId phiLabels[4] = {
+            readId, electBlockBeginId,
+            constUndefId, preElectBlockLabelId,
+        };
+        readId = ilcSpvPutPhi(compiler->module, compiler->uintId, 4, phiLabels);
+        readId = ilcSpvPutGroupNonUniformBroadcastFirst(compiler->module, compiler->uintId, workgroupScopeId, readId);
+        readId = ilcSpvPutOp2(compiler->module, instr->opcode == IL_OP_APPEND_BUF_ALLOC ? SpvOpIAdd : SpvOpISub, compiler->uintId, readId, laneIndexId);
+    }
+
+    IlcSpvId resId = emitVectorGrow(compiler, readId, compiler->uintId, 1);
     storeDestination(compiler, dst, resId, compiler->uint4Id);
 }
 

--- a/src/amdilc/amdilc_spirv.c
+++ b/src/amdilc/amdilc_spirv.c
@@ -463,6 +463,13 @@ IlcSpvId ilcSpvPutConstant(
     return putConstant(module, SpvOpConstant, resultTypeId, 1, &literal);
 }
 
+IlcSpvId ilcSpvPutConstantUndef(
+    IlcSpvModule* module,
+    IlcSpvId resultTypeId)
+{
+    return putConstant(module, SpvOpUndef, resultTypeId, 0, NULL);
+}
+
 IlcSpvId ilcSpvPutConstantComposite(
     IlcSpvModule* module,
     IlcSpvId resultTypeId,
@@ -471,6 +478,13 @@ IlcSpvId ilcSpvPutConstantComposite(
 {
     return putConstant(module, SpvOpConstantComposite, resultTypeId,
                        consistuentCount, consistuents);
+}
+
+IlcSpvId ilcSpvPutConstantTrue(
+    IlcSpvModule* module,
+    IlcSpvId resultTypeId)
+{
+    return putConstant(module, SpvOpConstantTrue, resultTypeId, 0, NULL);
 }
 
 void ilcSpvPutFunction(
@@ -925,6 +939,92 @@ IlcSpvId ilcSpvPutBitcast(
     putWord(buffer, resultTypeId);
     putWord(buffer, id);
     putWord(buffer, operandId);
+    return id;
+}
+
+IlcSpvId ilcSpvPutGroupNonUniformBallot(
+    IlcSpvModule* module,
+    IlcSpvId resultTypeId,
+    IlcSpvId scopeId,
+    IlcSpvId predicateId)
+{
+    IlcSpvBuffer* buffer = &module->buffer[ID_CODE];
+
+    IlcSpvId id = ilcSpvAllocId(module);
+    putInstr(buffer, SpvOpGroupNonUniformBallot, 5);
+    putWord(buffer, resultTypeId);
+    putWord(buffer, id);
+    putWord(buffer, scopeId);
+    putWord(buffer, predicateId);
+    return id;
+}
+
+IlcSpvId ilcSpvPutGroupNonUniformBallotBitCount(
+    IlcSpvModule* module,
+    IlcSpvId resultTypeId,
+    IlcSpvId scopeId,
+    SpvGroupOperation groupOperation,
+    IlcSpvId valueId)
+{
+    IlcSpvBuffer* buffer = &module->buffer[ID_CODE];
+
+    IlcSpvId id = ilcSpvAllocId(module);
+    putInstr(buffer, SpvOpGroupNonUniformBallotBitCount, 6);
+    putWord(buffer, resultTypeId);
+    putWord(buffer, id);
+    putWord(buffer, scopeId);
+    putWord(buffer, groupOperation);
+    putWord(buffer, valueId);
+    return id;
+}
+
+IlcSpvId ilcSpvPutGroupNonUniformElect(
+    IlcSpvModule* module,
+    IlcSpvId resultTypeId,
+    IlcSpvId scopeId)
+{
+    IlcSpvBuffer* buffer = &module->buffer[ID_CODE];
+
+    IlcSpvId id = ilcSpvAllocId(module);
+    putInstr(buffer, SpvOpGroupNonUniformElect, 4);
+    putWord(buffer, resultTypeId);
+    putWord(buffer, id);
+    putWord(buffer, scopeId);
+    return id;
+}
+
+IlcSpvId ilcSpvPutGroupNonUniformBroadcastFirst(
+    IlcSpvModule* module,
+    IlcSpvId resultTypeId,
+    IlcSpvId scopeId,
+    IlcSpvId valueId)
+{
+    IlcSpvBuffer* buffer = &module->buffer[ID_CODE];
+
+    IlcSpvId id = ilcSpvAllocId(module);
+    putInstr(buffer, SpvOpGroupNonUniformBroadcastFirst, 5);
+    putWord(buffer, resultTypeId);
+    putWord(buffer, id);
+    putWord(buffer, scopeId);
+    putWord(buffer, valueId);
+    return id;
+}
+
+IlcSpvId ilcSpvPutPhi(
+    IlcSpvModule* module,
+    IlcSpvId resultTypeId,
+    unsigned argCount,
+    const IlcSpvId* args)
+{
+    IlcSpvBuffer* buffer = &module->buffer[ID_CODE];
+
+    IlcSpvId id = ilcSpvAllocId(module);
+    putInstr(buffer, SpvOpPhi, 3 + argCount);
+    putWord(buffer, resultTypeId);
+    putWord(buffer, id);
+    for (unsigned i = 0; i < argCount; ++i) {
+        putWord(buffer, args[i]);
+    }
     return id;
 }
 

--- a/src/amdilc/amdilc_spirv.h
+++ b/src/amdilc/amdilc_spirv.h
@@ -149,11 +149,19 @@ IlcSpvId ilcSpvPutConstant(
     IlcSpvId resultTypeId,
     IlcSpvWord literal);
 
+IlcSpvId ilcSpvPutConstantUndef(
+    IlcSpvModule* module,
+    IlcSpvId resultTypeId);
+
 IlcSpvId ilcSpvPutConstantComposite(
     IlcSpvModule* module,
     IlcSpvId resultTypeId,
     unsigned consistuentCount,
     const IlcSpvId* consistuents);
+
+IlcSpvId ilcSpvPutConstantTrue(
+    IlcSpvModule* module,
+    IlcSpvId resultTypeId);
 
 void ilcSpvPutFunction(
     IlcSpvModule* module,
@@ -322,6 +330,36 @@ IlcSpvId ilcSpvPutBitcast(
     IlcSpvModule* module,
     IlcSpvId resultTypeId,
     IlcSpvId operandId);
+
+IlcSpvId ilcSpvPutGroupNonUniformBallot(
+    IlcSpvModule* module,
+    IlcSpvId resultTypeId,
+    IlcSpvId scopeId,
+    IlcSpvId predicateId);
+
+IlcSpvId ilcSpvPutGroupNonUniformBallotBitCount(
+    IlcSpvModule* module,
+    IlcSpvId resultTypeId,
+    IlcSpvId scopeId,
+    SpvGroupOperation groupOperation,
+    IlcSpvId valueId);
+
+IlcSpvId ilcSpvPutGroupNonUniformElect(
+    IlcSpvModule* module,
+    IlcSpvId resultTypeId,
+    IlcSpvId scopeId);
+
+IlcSpvId ilcSpvPutGroupNonUniformBroadcastFirst(
+    IlcSpvModule* module,
+    IlcSpvId resultTypeId,
+    IlcSpvId scopeId,
+    IlcSpvId valueId);
+
+IlcSpvId ilcSpvPutPhi(
+    IlcSpvModule* module,
+    IlcSpvId resultTypeId,
+    unsigned argCount,
+    const IlcSpvId* args);
 
 IlcSpvId ilcSpvPutSelect(
     IlcSpvModule* module,


### PR DESCRIPTION
# Changes to Mantle
Implemented per-command buffer atomic counter buffer operations for Mantle (grCmdSaveAtomicCounters, grCmdInitAtomicCounters) 
# Changes to amdilc
* Handle AMD IL operations for atomic counter buffer (`IL_OP_APPEND_BUF_ALLOC`, `IL_OP_APPEND_BUF_CONSUME`) which are used by BF4.
* Handle structured UAVs
* handle atomic operations on structured and raw UAVs
* handle atomic operations on structured and raw LDS
* handle `READ_ADD` and `READ_UMAX` atomic operations for both LDS and UAV