### PR TITLE
Add query pool functions

### DIFF
--- a/src/mantle/mantle_cmd_buf.c
+++ b/src/mantle/mantle_cmd_buf.c
@@ -1271,3 +1271,48 @@ GR_VOID GR_STDCALL grCmdResetEvent(
     VKD.vkCmdResetEvent(grCmdBuffer->commandBuffer, grEvent->event,
                         VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
 }
+
+GR_VOID GR_STDCALL grCmdBeginQuery(
+    GR_CMD_BUFFER cmdBuffer,
+    GR_QUERY_POOL queryPool,
+    GR_UINT slot,
+    GR_FLAGS flags)
+{
+    LOGT("%p %p %d %d\n", cmdBuffer, queryPool, slot, flags);
+
+    GrCmdBuffer* grCmdBuffer = (GrCmdBuffer*)cmdBuffer;
+    GrQueryPool* grQueryPool = (GrQueryPool*)queryPool;
+    const GrDevice* grDevice = GET_OBJ_DEVICE(grCmdBuffer);
+
+    VKD.vkCmdBeginQuery(grCmdBuffer->commandBuffer, grQueryPool->queryPool, slot,
+                        flags == GR_QUERY_IMPRECISE_DATA ? 0 : VK_QUERY_CONTROL_PRECISE_BIT);
+}
+
+GR_VOID GR_STDCALL grCmdEndQuery(
+    GR_CMD_BUFFER cmdBuffer,
+    GR_QUERY_POOL queryPool,
+    GR_UINT slot)
+{
+    LOGT("%p %p %d\n", cmdBuffer, queryPool, slot);
+
+    GrCmdBuffer* grCmdBuffer = (GrCmdBuffer*)cmdBuffer;
+    GrQueryPool* grQueryPool = (GrQueryPool*)queryPool;
+    const GrDevice* grDevice = GET_OBJ_DEVICE(grCmdBuffer);
+
+    VKD.vkCmdEndQuery(grCmdBuffer->commandBuffer, grQueryPool->queryPool, slot);
+}
+
+GR_VOID GR_STDCALL grCmdResetQueryPool(
+    GR_CMD_BUFFER cmdBuffer,
+    GR_QUERY_POOL queryPool,
+    GR_UINT startQuery,
+    GR_UINT queryCount)
+{
+    LOGT("%p %p %d %d\n", cmdBuffer, queryPool, startQuery, queryCount);
+
+    GrCmdBuffer* grCmdBuffer = (GrCmdBuffer*)cmdBuffer;
+    GrQueryPool* grQueryPool = (GrQueryPool*)queryPool;
+    const GrDevice* grDevice = GET_OBJ_DEVICE(grCmdBuffer);
+
+    VKD.vkCmdResetQueryPool(grCmdBuffer->commandBuffer, grQueryPool->queryPool, startQuery, queryCount);
+}

--- a/src/mantle/mantle_init_device.c
+++ b/src/mantle/mantle_init_device.c
@@ -524,6 +524,7 @@ GR_RESULT GR_STDCALL grCreateDevice(
             .multiViewport = VK_TRUE,
             .samplerAnisotropy = VK_TRUE,
             .fragmentStoresAndAtomics = VK_TRUE,
+            .occlusionQueryPrecise = VK_TRUE,
         },
     };
 

--- a/src/mantle/mantle_object.h
+++ b/src/mantle/mantle_object.h
@@ -318,6 +318,7 @@ typedef struct _GrShader {
 typedef struct _GrQueryPool {
     GrObject grObj;
     VkQueryPool queryPool;
+    VkQueryType queryType;
 } GrQueryPool;
 
 typedef struct _GrQueue {

--- a/src/mantle/stub.c
+++ b/src/mantle/stub.c
@@ -58,19 +58,6 @@ GR_RESULT GR_STDCALL grLoadPipeline(
     return GR_UNSUPPORTED;
 }
 
-// Query and Synchronization Functions
-
-GR_RESULT GR_STDCALL grGetQueryPoolResults(
-    GR_QUERY_POOL queryPool,
-    GR_UINT startQuery,
-    GR_UINT queryCount,
-    GR_SIZE* pDataSize,
-    GR_VOID* pData)
-{
-    LOGW("STUB\n");
-    return GR_UNSUPPORTED;
-}
-
 // Multi-Device Management Functions
 
 GR_RESULT GR_STDCALL grOpenSharedMemory(
@@ -138,32 +125,6 @@ GR_VOID GR_STDCALL grCmdMemoryAtomic(
     GR_GPU_SIZE destOffset,
     GR_UINT64 srcData,
     GR_ENUM atomicOp)
-{
-    LOGW("STUB\n");
-}
-
-GR_VOID GR_STDCALL grCmdBeginQuery(
-    GR_CMD_BUFFER cmdBuffer,
-    GR_QUERY_POOL queryPool,
-    GR_UINT slot,
-    GR_FLAGS flags)
-{
-    LOGW("STUB\n");
-}
-
-GR_VOID GR_STDCALL grCmdEndQuery(
-    GR_CMD_BUFFER cmdBuffer,
-    GR_QUERY_POOL queryPool,
-    GR_UINT slot)
-{
-    LOGW("STUB\n");
-}
-
-GR_VOID GR_STDCALL grCmdResetQueryPool(
-    GR_CMD_BUFFER cmdBuffer,
-    GR_QUERY_POOL queryPool,
-    GR_UINT startQuery,
-    GR_UINT queryCount)
 {
     LOGW("STUB\n");
 }


### PR DESCRIPTION
Implemented `grCmdBeginQuery`, `grCmdEndQuery`,`grCmdResetQueryPool` functions, also implemented `grGetQueryPoolResults`, although didn't implement fields reshuffle for pipeline statistics, but it isn't being used by BF4 (everything else in this commits is being used though).